### PR TITLE
Use rootPath if workspaceFolders is undefined

### DIFF
--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -11,7 +11,7 @@ const CycleTimeDataProvider = require('../lib/views/cycleTimeDataProvider')
 
 async function activate(context) {
   const rootPath = workspace.workspaceFolders && workspace.workspaceFolders[0].uri.fsPath
-  const isARepo = rootPath ? await isRepo(rootPath) : false
+  const isARepo = rootPath ? await isRepo(rootPath) : await isRepo(workspace.rootPath)
   context.workspaceState.update(common.globals.isARepo, isARepo)
 
   const cycleTimeProvider = new CycleTimeDataProvider(context)


### PR DESCRIPTION
* Bug - Incase `workspaceFolders` is undefined, app assumed the root was not a git repository
PR fixes to use `rootPath` if `workspaceFolders` is not defined.