### PR TITLE
Make all cards have black color text

### DIFF
--- a/lib/stats/css/statsStyle.js
+++ b/lib/stats/css/statsStyle.js
@@ -13,5 +13,6 @@ module.exports =
   background: #f6f6f6;
   padding: 10px;
   margin: 10px;
+  color: #000;
 }
 `


### PR DESCRIPTION
Fix stats card color issue in dark mode
#### Before
<img width="997" alt="screen shot 2018-09-19 at 21 16 29" src="https://user-images.githubusercontent.com/19430730/45772801-52a94d00-bc51-11e8-8a69-3bdbb4db090c.png">

#### After
<img width="973" alt="screen shot 2018-09-19 at 21 14 27" src="https://user-images.githubusercontent.com/19430730/45772693-12e26580-bc51-11e8-8b97-eed0e5dc33c3.png">

