### PR TITLE
Fix Took Nan hours error

### DIFF
--- a/lib/stats/templates/prepareUserCard.js
+++ b/lib/stats/templates/prepareUserCard.js
@@ -17,12 +17,11 @@ const countStoryTypes = stories => {
 module.exports = member => {
   let storyList = '', totalFeaturePoints = 0
   member.iteration_stories.forEach(story => {
-    if (story.story_type === 'feature' && story.current_state === 'accepted') {
+    if (story.story_type === 'feature' && story.current_state === 'accepted')
       totalFeaturePoints += story.estimate
-    }
     storyList += `
     <li><a href="${story.url}">${story.name} (is <b>${story.current_state}</b>)</a>
-      <p>Took ${getHoursFromSeconds(story.iteration_details.total_cycle_time)} hours</p>
+      <p>Took ${story.iteration_details.started_count === 0 ? 0 : getHoursFromSeconds(story.iteration_details.total_cycle_time)} hours</p>
       <ul>
         <li><i>Started ${story.iteration_details.started_count} times (${getHoursFromSeconds(story.iteration_details.started_time)} hours)</i></li>
         <li><i>Finished ${story.iteration_details.finished_count} times (${getHoursFromSeconds(story.iteration_details.finished_time)} hours)</i></li>


### PR DESCRIPTION
#### What does this PR do?
Fix error where `Took Nan hours displays if story was never started`

#### How should this be manually tested?
Go to `Member Cycle Time` and click on any iteration. Any story that was never started should report that it took 0 hours.

#### Any background context you want to provide?
n/a

#### Screenshots (if appropriate)
<img width="307" alt="Screen Shot 2019-04-30 at 20 23 58" src="https://user-images.githubusercontent.com/19430730/56980783-f06cdf00-6b85-11e9-9f10-46125610bbbc.png">


#### Questions:
n/a