### PR TITLE
Bg investigate cards not showing 165934409

### DIFF
--- a/lib/commands/showStats.js
+++ b/lib/commands/showStats.js
@@ -14,26 +14,27 @@ const onFail = () => window.showErrorMessage('Could not get member cycle')
 
 module.exports = async (context, scope = 'current', iterationNumber = 0) => {
   const accountResource = new PtAccounts(context)
-  let members
+  const iterationsResource = new PtIterations(context)
+  let members, iterations
   try {
     members = await accountResource.getMemberships()
+    iterations = await iterationsResource.getIterations(scope)
   } catch (error) {
-    onFail()
+    return onFail()
   }
   const allMembersById = memberIdToKey(members.data)
 
-  const iterationsResource = new PtIterations(context)
-  let iterations
-  try {
-    iterations = await iterationsResource.getIterations(scope)    
-  } catch (error) {
-    onFail()
-  }
   const iterationIndex = iterationNumber ? iterationNumber - 1 : 0
   const  allIterationStories = propertyToKey(iterations.data[iterationIndex].stories, 'id')
   
   const itNumber = iterationNumber || iterations.data[0].number
-  const iterationCycle = await iterationsResource.getIterationCycleTime(itNumber)
+  let iterationCycle
+
+  try {
+    iterationCycle = await iterationsResource.getIterationCycleTime(itNumber)
+  } catch(e) {
+    return onFail()
+  }
 
   mapCycleTimeToStory(allIterationStories, iterationCycle.data)
   mapStoryToMember(allMembersById, allIterationStories)

--- a/lib/commands/showStats.spec.js
+++ b/lib/commands/showStats.spec.js
@@ -1,0 +1,24 @@
+jest.mock('../../model/accounts')
+jest.mock('../../model/iterations')
+const vscode = require('vscode')
+const PtAccount = require('../../model/accounts')
+const PtIteration = require('../../model/iterations')
+const showStats = require('./showStats')
+const Context = require('../../test/factories/vscode/context')
+
+const context = Context.build()
+
+describe('#showStats', () => {
+  test('it should fail if authentication fails and show error message', async () => {
+    vscode.window.showErrorMessage = jest.fn().mockResolvedValue('failed')
+    PtAccount.mockImplementationOnce(jest.fn().mockReturnValue({
+      getMemberships: jest.fn().mockRejectedValue('invalid_authentication')
+    }))
+    PtIteration.mockImplementationOnce(jest.fn().mockReturnValue({
+      getIterations: jest.fn().mockRejectedValue('invalid_authentication'),
+      getIterationCycleTime: jest.fn().mockRejectedValue('invalid_authentication')
+    }))
+    const stats = await showStats(context)
+    expect(stats).toBe('failed')
+  })
+})

--- a/lib/utils/date.js
+++ b/lib/utils/date.js
@@ -7,7 +7,7 @@ class DateUtil {
 
   /**
    * 
-   * @param {string} time utc time string
+   * @param {string | object | Date} time utc time string or moment or Date object
    * @param {number} difference number of units ago
    * @param {string} unit unit of time e.g.'months', 'seconds'
    */

--- a/lib/utils/date.js
+++ b/lib/utils/date.js
@@ -1,9 +1,19 @@
 const moment = require('moment')
 
-class DateFormatter {
+class DateUtil {
   static formatDate(date, format) {
     return moment(date).format(format)
   }
+
+  /**
+   * 
+   * @param {string} time utc time string
+   * @param {number} difference number of units ago
+   * @param {string} unit unit of time e.g.'months', 'seconds'
+   */
+  static isBefore(time, difference, unit) {
+    return moment(time).isBefore(moment().subtract(difference, unit))
+  }
 }
 
-module.exports = DateFormatter
+module.exports = DateUtil

--- a/lib/utils/date.spec.js
+++ b/lib/utils/date.spec.js
@@ -1,12 +1,26 @@
 const dateUtil = require('./date')
+const moment = require('moment')
 
-describe('#DateFormatter', () => {
+describe('#DateUtil', () => {
   describe('formatDate', () => {
     it('should format date according to moment format provided', () => {
       let formattedDate = dateUtil.formatDate('2018-08-14T12:01:00Z', 'YY')
       expect(formattedDate).toBe('18')
       formattedDate = dateUtil.formatDate('2018-08-14T12:01:00Z', 'MM-YY')
       expect(formattedDate).toBe('08-18')      
+    })
+  })
+
+  describe('isBefore', () => {
+    const timeToTest = moment().subtract(5, 'weeks')
+    it('should return true if given time is before specified units ago', () => {
+      const isTimeBefore = dateUtil.isBefore(timeToTest, 4, 'weeks')
+      expect(isTimeBefore).toBe(true)
+    })
+
+    it('should return false if given time is before specified units ago', () => {
+      const isTimeBefore = dateUtil.isBefore(timeToTest, 8, 'weeks')
+      expect(isTimeBefore).toBe(false)
     })
   })
 })

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -1,3 +1,4 @@
+const {isBefore} = require('../../utils/date')
 const {TreeItem, TreeItemCollapsibleState} = require('vscode')
 const PtIterations = require('../../../model/iterations')
 const {commands} = require('../../commands')
@@ -5,10 +6,12 @@ const IterationPortalItem = require('./iterationPortalItem')
 const {testMatch, expressions} = require('../../utils/regularExpressions')
 
 class CycleTimeTreeDataProvider {
-  constructor(context) {
+  constructor(context, maxPeriod) {
     this._context = context
     this._scope = 'done_current'
     this._portal = {}
+    this._iterationsNotAvailableMessage = [new TreeItem(`There are no available iterations from the last ${maxPeriod.length} ${maxPeriod.unit}.`)]
+    this._maxPeriod = maxPeriod
   }
 
   async getChildren(element) {
@@ -20,9 +23,10 @@ class CycleTimeTreeDataProvider {
     }
     // start
     const iterations = await this._getIterations()
-    if(!iterations) return [new TreeItem('There are no available iterations')]
+    if(!iterations) return this._iterationsNotAvailableMessage
     this._createIterationPortal(iterations)
     const years = this._getYears()
+    if(years.length === 0) return this._iterationsNotAvailableMessage
     return years
   }
 
@@ -44,6 +48,7 @@ class CycleTimeTreeDataProvider {
   _createIterationPortal(iterations) {
     const portal = {}
     iterations.forEach(iteration => {
+      if(isBefore(iteration.start, this._maxPeriod.length, this._maxPeriod.unit)) return
       const portalitem = new IterationPortalItem(iteration)
       if(portal.hasOwnProperty(portalitem.year)){
         if(portal[portalitem.year].hasOwnProperty(portalitem.month))

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -36,7 +36,7 @@ class CycleTimeTreeDataProvider {
     try {
       iterations = await iterationResource.getIterations(this._scope)
     } catch (error) {
-      return []
+      return null
     }
     return iterations.data
   }

--- a/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
@@ -199,5 +199,23 @@ describe('#cycleTimeDataProvider', () => {
       const itStart = now.clone(), itFinish = now.clone().add(1, 'weeks')
       expect(provider._portal[thisYear][thisMonth][0].label).toBe(`${itStart.format('D-MMM-YYYY')} to ${itFinish.format('D-MMM-YYYY')}`)
     })
+
+    it('should not add items older than specified period', () => {
+      const provider = new cycleTimeDataProvider(context, {length: 2, unit: 'months'})
+      provider._createIterationPortal([
+        {
+          start: now.clone().add(1, 'weeks').utc().format(),
+          finish: now.clone().add(2, 'weeks').utc().format(),
+          number: 2,
+        },
+        {
+          start: now.clone().subtract(1, 'years').utc().format(),
+          finish: now.clone().subtract(1, 'years').add(1, 'weeks').utc().format(),
+          number: 2,
+        }
+      ])
+      expect(provider._portal).toHaveProperty(thisYear)
+      expect(provider._portal).not.toHaveProperty(lastYear)
+    })
   })
 })

--- a/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
@@ -1,8 +1,12 @@
 jest.mock('../../../model/iterations')
+const moment = require('moment')
 const cycleTimeDataProvider = require('./cycleTimeDataProvider')
 const PtIterations = require('../../../model/iterations')
 const {TreeItem} = require('vscode')
 const {commands} = require('../../commands')
+const Context = require('../../../test/factories/vscode/context')
+
+const context = Context.build()
 
 const portal = {
   2018: {
@@ -21,15 +25,15 @@ describe('#cycleTimeDataProvider', () => {
   describe('getChildren', () => {
     let provider
     beforeEach(() => {
-      provider = new cycleTimeDataProvider({})
+      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      provider._createIterationPortal = jest.fn()
       provider._portal = portal
     })
 
     it('should get get years if no element is passed', async () => {
-      PtIterations.mockImplementation(() => ({
+      PtIterations.mockImplementation(jest.fn().mockReturnValue({
         getIterations: () => ({data: []})
       }))
-      provider._createIterationPortal = jest.fn()
       const items = await provider.getChildren()
       expect(typeof items).toBe('object')
       expect(items.length).toBe(1)
@@ -56,16 +60,16 @@ describe('#cycleTimeDataProvider', () => {
 
   describe('getTreeItem', () => {
     it('should return the element passed to it', () => {
-      const item = new cycleTimeDataProvider({}).getTreeItem(4)
+      const item = new cycleTimeDataProvider(context, {length: 20, unit: 'years'}).getTreeItem(4)
       expect(item).toBe(4)
     })
   })
 
   describe('_getIterations', async () => {
-    let getIterationsMock = jest.fn().mockReturnValue({data: []})
+    let getIterationsMock = jest.fn().mockResolvedValue({data: []})
 
     beforeEach(() => {
-      PtIterations.mockImplementation(() => ({
+      PtIterations.mockImplementation(jest.fn().mockReturnValue({
         getIterations: getIterationsMock
       }))
     })
@@ -73,25 +77,25 @@ describe('#cycleTimeDataProvider', () => {
     afterEach(() => PtIterations.mockClear())
 
     it('should get iterations from the model', async () => {
-      const provider = new cycleTimeDataProvider()
+      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       await provider._getIterations()
       expect(getIterationsMock).toHaveBeenCalledTimes(1)
     })
 
     it('should use done_current scope', async () => {
-      const provider = new cycleTimeDataProvider('context')
+      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       await provider._getIterations()
       expect(getIterationsMock.mock.calls[0][0]).toBe('done_current')
     })
 
-    it('should return an empty array if authentication fails', async () => {
+    it('should return null if authentication fails', async () => {
       PtIterations.mockClear()
-      PtIterations.mockImplementationOnce(() => ({
+      PtIterations.mockImplementationOnce(jest.fn().mockReturnValue({
         getIterations: jest.fn().mockRejectedValueOnce('invalid_authentication')
       }))
-      const provider = new cycleTimeDataProvider()
+      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       const iterations = await provider._getIterations()
-      expect(iterations).toMatchObject([])
+      expect(iterations).toBe(null)
     })
   })
 
@@ -99,7 +103,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider({})
+      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       provider._portal = portal
     })
 
@@ -114,7 +118,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider({})
+      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       provider._portal = portal
     })
 
@@ -134,7 +138,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider('context')
+      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
       provider._portal = portal
     })
 
@@ -149,7 +153,7 @@ describe('#cycleTimeDataProvider', () => {
       expect(item[0].command.title).toBe('View Stats')
       expect(item[0].command.command).toBe(commands.statistics.cycleTime)
       expect(item[0].command.arguments).toHaveLength(3)
-      expect(item[0].command.arguments[0]).toBe('context')
+      expect(context).toMatchObject(item[0].command.arguments[0])
       expect(item[0].command.arguments[1]).toBe(provider._scope)
       expect(item[0].command.arguments[2]).toBe(25)
       expect(item[0].tooltip).toBe('View iteration stats')
@@ -157,34 +161,43 @@ describe('#cycleTimeDataProvider', () => {
   })
 
   describe('_createIterationPortal', () => {
+    const now = moment()
     const iterations = [
       {
-        start: '2018-08-14T12:01:00Z',
-        finish: '2018-08-21T12:01:00Z',
+        start: now.utc().format(),
+        finish: now.clone().add(1, 'weeks').utc().format(),
         number: 2,
       },
       {
-        start: '2017-07-14T12:01:00Z',
-        finish: '2017-07-21T12:01:00Z',
+        start: now.clone().subtract(1, 'years').utc().format(),
+        finish: now.clone().subtract(1, 'years').add(1, 'weeks').utc().format(),
         number: 2,
       },
       {
-        start: '2017-08-14T12:01:00Z',
-        finish: '2017-08-21T12:01:00Z',
+        start: now.clone().subtract(1, 'years').add(1, 'months').utc().format(),
+        finish: now.clone().subtract(1, 'years').add(1, 'months').add(1, 'weeks').utc().format(),
         number: 2,
       }
     ]
 
+    const thisYear = now.format('YYYY'), 
+    lastYear = now.clone().subtract(1, 'years').format('YYYY'),
+    thisMonth = now.format('MMMM'),
+    thisMonthLastYear = now.clone().subtract(1, 'years').format('MMMM'),
+    yearOfDynamicCase = now.clone().subtract(1, 'years').add(1, 'months').utc().format('YYYY'),
+    monthOfDynamicCase = now.clone().subtract(1, 'years').add(1, 'months').utc().format('MMMM')
+
     it('should create a portal object given iterations', () => {
-      const provider = new cycleTimeDataProvider('context')
+      const provider = new cycleTimeDataProvider(context, {length: 2, unit: 'years'})
       provider._createIterationPortal(iterations)
-      expect(provider._portal).toHaveProperty('2018')
-      expect(provider._portal).toHaveProperty('2017')
-      expect(provider._portal[2018]).toHaveProperty('August')
-      expect(provider._portal[2017]).toHaveProperty('August')
-      expect(provider._portal[2017]).toHaveProperty('July')
-      expect(provider._portal[2018].August).toHaveLength(1)
-      expect(provider._portal[2018].August[0].label).toBe('14-Aug-2018 to 21-Aug-2018')
+      expect(provider._portal).toHaveProperty(thisYear) // this year
+      expect(provider._portal).toHaveProperty(lastYear) // last year
+      expect(provider._portal[thisYear]).toHaveProperty(thisMonth)
+      expect(provider._portal[lastYear]).toHaveProperty(thisMonthLastYear)
+      expect(provider._portal[yearOfDynamicCase]).toHaveProperty(monthOfDynamicCase)
+      expect(provider._portal[thisYear][thisMonth]).toHaveLength(1)
+      const itStart = now.clone(), itFinish = now.clone().add(1, 'weeks')
+      expect(provider._portal[thisYear][thisMonth][0].label).toBe(`${itStart.format('D-MMM-YYYY')} to ${itFinish.format('D-MMM-YYYY')}`)
     })
   })
 })

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -24,10 +24,11 @@ const activate = async context => {
 
   const statusBarItem = createPTStatusBarItem()
 
-  const cycleTimeProvider = new CycleTimeDataProvider(context)
+  const cycleTimeProvider = new CycleTimeDataProvider(context, {length: 6, unit: 'months'})
   const storyInfoProvider = new StoryInfoDataProvider(context)
   const cpProvider = new ControlPanelDataProvider(context, statusBarItem)
 
+  // TODO: Use call back function without wrapping it in another anonymous function
   context.subscriptions.push(
     statusBarItem,
     window.registerTreeDataProvider(views.memberCycle, cycleTimeProvider),


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where some iterations don't show statistics when clicked

#### How should this be manually tested?
Open the app. Under `Member Cycle Time`, all iterations should bring forth corresponding cards with iteration details.

#### Any background context you want to provide?
Statistics for iterations older than 6 months are unavailable.

#### Screenshots (if appropriate)
n/a

#### Questions:
n/a
