### PR TITLE
Bg Irregular iterations in member cycle view 165971846

### DIFF
--- a/lib/commands/linkStory.js
+++ b/lib/commands/linkStory.js
@@ -18,7 +18,7 @@ const linkStory = async context => {
   const iterationsResource = new PtIterations(context)
   let currentBacklog
   try {
-    currentBacklog = (await iterationsResource.getIterations('current_backlog')).data    
+    currentBacklog = (await iterationsResource.getIterations({scope: 'current_backlog', limit: 1000})).data    
   } catch (error) {
     return window.showErrorMessage('Failed to get stories')
   }

--- a/lib/commands/showAllCommands.js
+++ b/lib/commands/showAllCommands.js
@@ -3,44 +3,42 @@ const _ = require('lodash')
 const {getState} = require("../helpers/state")
 const {storyState, workState, statistics} = require("./commands").commands
 const getAllKeys = require('../adapters/getAllKeys')
-const {model} = require('../../model')
-
-const textToCommandMapping = {
-  storyState: {
-    "$(triangle-right)\tStart Story": storyState.startStory,
-    "$(primitive-square)\tStop Story": storyState.stopStory,
-    "$(check)\tFinish Story": storyState.finishStory,
-    "$(briefcase)\tDeliver Story": storyState.deliverStory
-  },
-  workState: {
-    "$(link)\tLink Story": workState.linkStory
-  },
-  statistics: {
-    "$(history)\tMembers Cycle Time (Current iteration)": statistics.cycleTime
-  }
-}
-
-const getCommands = key => getAllKeys(textToCommandMapping[key])
 
 module.exports = async context => {
+  const textToCommandMapping = {
+    "$(triangle-right)\tStart Story": {
+      command: storyState.startStory,
+      args: [context]
+    },
+    "$(primitive-square)\tStop Story": {
+      command: storyState.stopStory,
+      args: [context]
+    },
+    "$(check)\tFinish Story": {
+      command: storyState.finishStory,
+      args: [context]
+    },
+    "$(briefcase)\tDeliver Story": {
+      command: storyState.deliverStory,
+      args: [context]
+    },
+    "$(link)\tLink Story": {
+      command: workState.linkStory,
+      args: [context]
+    }
+  }
+  
+  const getCommands = key => getAllKeys(textToCommandMapping[key])
+
   const state = getState(context)
   const placeHolder = state.story ? `(${state.story}) ${state.storyDetails.name}` : `Pick action`
-  const allCommands =
-  getCommands('storyState')
-  .concat(getCommands('workState'))
-  .concat(getCommands('statistics'))
+  const allCommands = getAllKeys(textToCommandMapping)
 
   const relevantCommands = state.story ? allCommands
    : _.difference(allCommands, getCommands('storyState'))
 
-  const mashedCommands = Object.assign({},
-    textToCommandMapping.statistics,
-    textToCommandMapping.storyState,
-    textToCommandMapping.workState
-    )
-
   const pickedItem = window.showQuickPick(relevantCommands, { canPickMany: false, ignoreFocusOut: true, placeHolder})
   pickedItem.then(action =>
-    commands.executeCommand(mashedCommands[action], context)
+    commands.executeCommand(textToCommandMapping[action].command, ...textToCommandMapping[action].args)
   )
 }

--- a/lib/commands/showStats.js
+++ b/lib/commands/showStats.js
@@ -12,26 +12,23 @@ const statsCss = require('../stats/css/statsStyle')
 
 const onFail = () => window.showErrorMessage('Could not get member cycle')
 
-module.exports = async (context, scope = 'current', iterationNumber = 0) => {
+module.exports = async (context, iteration) => {
   const accountResource = new PtAccounts(context)
   const iterationsResource = new PtIterations(context)
-  let members, iterations
+
+  let members
   try {
     members = await accountResource.getMemberships()
-    iterations = await iterationsResource.getIterations(scope)
   } catch (error) {
     return onFail()
   }
   const allMembersById = memberIdToKey(members.data)
 
-  const iterationIndex = iterationNumber ? iterationNumber - 1 : 0
-  const  allIterationStories = propertyToKey(iterations.data[iterationIndex].stories, 'id')
-  
-  const itNumber = iterationNumber || iterations.data[0].number
-  let iterationCycle
+  const allIterationStories = propertyToKey(iteration.stories, 'id')
 
+  let iterationCycle
   try {
-    iterationCycle = await iterationsResource.getIterationCycleTime(itNumber)
+    iterationCycle = await iterationsResource.getIterationCycleTime(iteration.number)
   } catch(e) {
     return onFail()
   }
@@ -41,7 +38,7 @@ module.exports = async (context, scope = 'current', iterationNumber = 0) => {
 
   const dataView = getAllMemberCards(allMembersById)
   const statsHtml = createDoc(dataView, statsCss)
-  const startDate = formatDate(iterations.data[iterationIndex].start, 'DD.MM.YY')
+  const startDate = formatDate(iteration.start, 'DD.MM.YY')
   const statsPanel = window.createWebviewPanel('pivotaly.stats', `Statistics - ${startDate}`, ViewColumn.One, {enableFindWidget: true})
   statsPanel.webview.html = statsHtml
 }

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -7,11 +7,17 @@ const IterationPortalItem = require('./iterationPortalItem')
 const {testMatch, expressions} = require('../../utils/regularExpressions')
 
 class CycleTimeTreeDataProvider {
+  /**
+   * 
+   * @param {object} context extension host context
+   * @param {number} maxPeriod maximum number of months to get iterations from
+   * @param {string} scope scope of iterations
+   */
   constructor(context, maxPeriod, scope) {
     this._context = context
     this._scope = scope
     this._portal = {}
-    this._iterationsNotAvailableMessage = [new TreeItem(`There are no available iterations from the last ${maxPeriod.length} ${maxPeriod.unit}.`)]
+    this._iterationsNotAvailableMessage = [new TreeItem(`There are no available iterations from the last ${maxPeriod} months.`)]
     this._maxPeriod = maxPeriod
   }
 
@@ -36,7 +42,8 @@ class CycleTimeTreeDataProvider {
   }
 
   async _getIterations() {
-    const iterationResource = new PtIterations(this._context)
+    const maxIterations = this._maxPeriod * 4 + this._maxPeriod
+    const iterationResource = new PtIterations(this._context, maxIterations) // maximum iterations in given month
     let iterations
     try {
       iterations = await iterationResource.getIterations(this._scope)
@@ -50,7 +57,7 @@ class CycleTimeTreeDataProvider {
     const portal = {}
     if(_.isArray(iterations))
       iterations.forEach(iteration => {
-        if(isBefore(iteration.start, this._maxPeriod.length, this._maxPeriod.unit)) return
+        if(isBefore(iteration.start, this._maxPeriod, 'months')) return
         const portalitem = new IterationPortalItem(iteration)
         if(portal.hasOwnProperty(portalitem.year)){
           if(portal[portalitem.year].hasOwnProperty(portalitem.month))

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const {isBefore} = require('../../utils/date')
 const {TreeItem, TreeItemCollapsibleState} = require('vscode')
 const PtIterations = require('../../../model/iterations')
@@ -47,20 +48,21 @@ class CycleTimeTreeDataProvider {
 
   _createIterationPortal(iterations) {
     const portal = {}
-    iterations.forEach(iteration => {
-      if(isBefore(iteration.start, this._maxPeriod.length, this._maxPeriod.unit)) return
-      const portalitem = new IterationPortalItem(iteration)
-      if(portal.hasOwnProperty(portalitem.year)){
-        if(portal[portalitem.year].hasOwnProperty(portalitem.month))
-          portal[portalitem.year][portalitem.month].push(portalitem)      
-        else
-          portal[portalitem.year][portalitem.month] = [portalitem]
-      } else {
-        portal[portalitem.year] = {
-          [portalitem.month]: [portalitem]
+    if(_.isArray(iterations))
+      iterations.forEach(iteration => {
+        if(isBefore(iteration.start, this._maxPeriod.length, this._maxPeriod.unit)) return
+        const portalitem = new IterationPortalItem(iteration)
+        if(portal.hasOwnProperty(portalitem.year)){
+          if(portal[portalitem.year].hasOwnProperty(portalitem.month))
+            portal[portalitem.year][portalitem.month].push(portalitem)      
+          else
+            portal[portalitem.year][portalitem.month] = [portalitem]
+        } else {
+          portal[portalitem.year] = {
+            [portalitem.month]: [portalitem]
+          }
         }
-      }
-    })
+      })
     this._portal = portal
   }
 

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -6,9 +6,9 @@ const IterationPortalItem = require('./iterationPortalItem')
 const {testMatch, expressions} = require('../../utils/regularExpressions')
 
 class CycleTimeTreeDataProvider {
-  constructor(context, maxPeriod) {
+  constructor(context, maxPeriod, scope) {
     this._context = context
-    this._scope = 'done_current'
+    this._scope = scope
     this._portal = {}
     this._iterationsNotAvailableMessage = [new TreeItem(`There are no available iterations from the last ${maxPeriod.length} ${maxPeriod.unit}.`)]
     this._maxPeriod = maxPeriod

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -46,7 +46,7 @@ class CycleTimeTreeDataProvider {
     const iterationResource = new PtIterations(this._context)
     let iterations
     try {
-      iterations = await iterationResource.getIterations(this._scope, this._maxIterations)
+      iterations = await iterationResource.getDoneIterations(this._scope, this._maxIterations)
     } catch (error) {
       return null
     }

--- a/lib/views/memberCycletime/cycleTimeDataProvider.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.js
@@ -19,6 +19,7 @@ class CycleTimeTreeDataProvider {
     this._portal = {}
     this._iterationsNotAvailableMessage = [new TreeItem(`There are no available iterations from the last ${maxPeriod} months.`)]
     this._maxPeriod = maxPeriod
+    this._maxIterations = maxPeriod * 4 + maxPeriod // maximum iterations in given month
   }
 
   async getChildren(element) {
@@ -42,11 +43,10 @@ class CycleTimeTreeDataProvider {
   }
 
   async _getIterations() {
-    const maxIterations = this._maxPeriod * 4 + this._maxPeriod
-    const iterationResource = new PtIterations(this._context, maxIterations) // maximum iterations in given month
+    const iterationResource = new PtIterations(this._context)
     let iterations
     try {
-      iterations = await iterationResource.getIterations(this._scope)
+      iterations = await iterationResource.getIterations(this._scope, this._maxIterations)
     } catch (error) {
       return null
     }
@@ -87,7 +87,7 @@ class CycleTimeTreeDataProvider {
       iterationItem.command = {
         title: 'View Stats',
         command: commands.statistics.cycleTime,
-        arguments: [this._context, this._scope, iteration.iterationNumber]
+        arguments: [this._context, iteration.iteration]
       }
       iterationItem.tooltip = 'View iteration stats'
       return iterationItem

--- a/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
+++ b/lib/views/memberCycletime/cycleTimeDataProvider.spec.js
@@ -12,7 +12,11 @@ const portal = {
   2018: {
     January: [{
       label: '20th - 23rd',
-      iterationNumber: 25
+      iterationNumber: 25,
+      iteration: {
+        number: 1,
+        stories: []
+      }
     }]
   }
 }
@@ -25,14 +29,14 @@ describe('#cycleTimeDataProvider', () => {
   describe('getChildren', () => {
     let provider
     beforeEach(() => {
-      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      provider = new cycleTimeDataProvider(context, 6, 'done_current')
       provider._createIterationPortal = jest.fn()
       provider._portal = portal
     })
 
-    it('should get get years if no element is passed', async () => {
+    it('should get years if no element is passed', async () => {
       PtIterations.mockImplementation(jest.fn().mockReturnValue({
-        getIterations: () => ({data: []})
+        getDoneIterations: () => ({data: [{number: 1}]})
       }))
       const items = await provider.getChildren()
       expect(typeof items).toBe('object')
@@ -56,11 +60,28 @@ describe('#cycleTimeDataProvider', () => {
       expect(items.length).toBe(1)
       expect(items[0].label).toBe('20th - 23rd')
     })
+
+    it('should return iterations unavailable message if there are no iterations', async () => {
+      PtIterations.mockImplementation(jest.fn().mockReturnValue({
+        getDoneIterations: () => ({data: []})
+      }))
+      const items = await provider.getChildren()
+      expect(items[0].toString()).toBe(provider._iterationsNotAvailableMessage[0].toString())
+    })
+
+    it('should return iterations unavailable message if there are no years', async () => {
+      PtIterations.mockImplementation(jest.fn().mockReturnValue({
+        getDoneIterations: () => ({data: [{number: 1}]})
+      }))
+      provider._portal = {}
+      const items = await provider.getChildren()
+      expect(items[0].toString()).toBe(provider._iterationsNotAvailableMessage[0].toString())
+    })
   })
 
   describe('getTreeItem', () => {
     it('should return the element passed to it', () => {
-      const item = new cycleTimeDataProvider(context, {length: 20, unit: 'years'}).getTreeItem(4)
+      const item = new cycleTimeDataProvider(context, 6, 'done').getTreeItem(4)
       expect(item).toBe(4)
     })
   })
@@ -70,22 +91,22 @@ describe('#cycleTimeDataProvider', () => {
 
     beforeEach(() => {
       PtIterations.mockImplementation(jest.fn().mockReturnValue({
-        getIterations: getIterationsMock
+        getDoneIterations: getIterationsMock
       }))
     })
 
     afterEach(() => PtIterations.mockClear())
 
     it('should get iterations from the model', async () => {
-      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      const provider = new cycleTimeDataProvider(context, 6, 'done')
       await provider._getIterations()
       expect(getIterationsMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should use done_current scope', async () => {
-      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+    it('should use provided scope', async () => {
+      const provider = new cycleTimeDataProvider(context, 6, 'done')
       await provider._getIterations()
-      expect(getIterationsMock.mock.calls[0][0]).toBe('done_current')
+      expect(getIterationsMock.mock.calls[0][0]).toBe('done')
     })
 
     it('should return null if authentication fails', async () => {
@@ -93,7 +114,7 @@ describe('#cycleTimeDataProvider', () => {
       PtIterations.mockImplementationOnce(jest.fn().mockReturnValue({
         getIterations: jest.fn().mockRejectedValueOnce('invalid_authentication')
       }))
-      const provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      const provider = new cycleTimeDataProvider(context, 6, 'done')
       const iterations = await provider._getIterations()
       expect(iterations).toBe(null)
     })
@@ -103,7 +124,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      provider = new cycleTimeDataProvider(context, 6, 'done')
       provider._portal = portal
     })
 
@@ -118,7 +139,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      provider = new cycleTimeDataProvider(context, 6, 'done')
       provider._portal = portal
     })
 
@@ -138,7 +159,7 @@ describe('#cycleTimeDataProvider', () => {
     let provider
 
     beforeEach(() => {
-      provider = new cycleTimeDataProvider(context, {length: 20, unit: 'years'})
+      provider = new cycleTimeDataProvider(context, 6, 'done')
       provider._portal = portal
     })
 
@@ -152,10 +173,9 @@ describe('#cycleTimeDataProvider', () => {
       const item = provider._getTreeIterations('2018', 'January')
       expect(item[0].command.title).toBe('View Stats')
       expect(item[0].command.command).toBe(commands.statistics.cycleTime)
-      expect(item[0].command.arguments).toHaveLength(3)
+      expect(item[0].command.arguments).toHaveLength(2)
       expect(context).toMatchObject(item[0].command.arguments[0])
-      expect(item[0].command.arguments[1]).toBe(provider._scope)
-      expect(item[0].command.arguments[2]).toBe(25)
+      expect(item[0].command.arguments[1]).toMatchObject(portal[2018].January[0].iteration)
       expect(item[0].tooltip).toBe('View iteration stats')
     })
   })
@@ -188,7 +208,7 @@ describe('#cycleTimeDataProvider', () => {
     monthOfDynamicCase = now.clone().subtract(1, 'years').add(1, 'months').utc().format('MMMM')
 
     it('should create a portal object given iterations', () => {
-      const provider = new cycleTimeDataProvider(context, {length: 2, unit: 'years'})
+      const provider = new cycleTimeDataProvider(context, 20, 'done')
       provider._createIterationPortal(iterations)
       expect(provider._portal).toHaveProperty(thisYear) // this year
       expect(provider._portal).toHaveProperty(lastYear) // last year
@@ -201,7 +221,7 @@ describe('#cycleTimeDataProvider', () => {
     })
 
     it('should not add items older than specified period', () => {
-      const provider = new cycleTimeDataProvider(context, {length: 2, unit: 'months'})
+      const provider = new cycleTimeDataProvider(context, 1, 'done')
       provider._createIterationPortal([
         {
           start: now.clone().add(1, 'weeks').utc().format(),

--- a/lib/views/memberCycletime/iterationPortalItem.js
+++ b/lib/views/memberCycletime/iterationPortalItem.js
@@ -3,18 +3,27 @@ const {formatDate} = require('../../utils/date')
 
 class IterationPortalItem {
   constructor(iteration) {
-    this.year = this._getYear(iteration.start)
-    this.month = this._getMonth(iteration.start)
-    this.iterationNumber = iteration.number
-    this.label = `${formatDate(iteration.start, 'DD-MMM-YYYY')} to ${formatDate(iteration.finish, 'DD-MMM-YYYY')}`
+    this._iteration = iteration
   }
 
-  _getYear(startDate) {
-    return formatDate(startDate, 'YYYY')
+  get year() {
+    return formatDate(this._iteration.start, 'YYYY')
   }
 
-  _getMonth(startDate) {
-    return formatDate(startDate, 'MMMM')
+  get month() {
+    return formatDate(this._iteration.start, 'MMMM')
+  }
+
+  get iterationNumber() {
+    return this._iteration.number
+  }
+
+  get label() {
+    return `${formatDate(this._iteration.start, 'DD-MMM-YYYY')} to ${formatDate(this._iteration.finish, 'DD-MMM-YYYY')}`
+  }
+
+  get iteration() {
+    return this._iteration
   }
 }
 

--- a/lib/views/memberCycletime/iterationPortalItem.spec.js
+++ b/lib/views/memberCycletime/iterationPortalItem.spec.js
@@ -8,17 +8,43 @@ const iteration = {
 const portalItem = new iterationPortalItem(iteration)
 
 describe('#iterationPortalItem', () => {
-  describe('_getYear', () => {
-    it('should return year', () => {
-      const year = portalItem._getYear(iteration.start)
-      expect(year).toBe('2017')
+  describe('properties', () => {
+    describe('year', () => {
+      it('should return year', () => {
+        const year = portalItem.year
+        expect(year).toBe('2017')
+      })
     })
-  })
 
-  describe('_getMonth', () => {
-    it('should return month', () => {
-      const month = portalItem._getMonth(iteration.start)
-      expect(month).toBe('August')
+    describe('month', () => {
+      it('should return month', () => {
+        const month = portalItem.month
+        expect(month).toBe('August')
+      })
+    })
+
+    describe('iterationNumber', () => {
+      it('should return iteration number', () => {
+        const number = portalItem.iterationNumber
+        expect(number).toBe(25)
+      })
+    })
+
+    describe('label', () => {
+      it('should be label from start to finish', () => {
+        const label = portalItem.label
+        expect(label).toBe('14-Aug-2017 to 21-Aug-2017')
+      })
+    })
+
+    describe('iteration', () => {
+      it('should be the actual iteration object', () => {
+        const sIteration = portalItem.iteration
+        expect(iteration).toMatchObject(sIteration)
+      })
     })
   })
+  
+
+  
 })

--- a/model/index.js
+++ b/model/index.js
@@ -1,4 +1,5 @@
 const clients = require('restify-clients')
+const _ = require('lodash')
 const {common} = require('../lib/commands/common')
 const {normaliseFields} = require('../lib/adapters/normaliseFields')
 const requestToken = require('../lib/procedures/requestToken')
@@ -51,6 +52,22 @@ class Model {
   _appendFields(path, fields) {
     fields = normaliseFields(fields).join()
     return fields.length > 0 ? `${path}?fields=${fields}` : path
+  }
+
+  /**
+   * Adds parameters to a url string
+   * @param {string} path url path
+   * @param {object} params object with keys as param fields and values as their respective values
+   * @returns {string} url appended with various params
+   */
+  _addParams(path, params) {
+    if(path[path.length - 1] === '/') path = path.substring(0, path.length - 1)
+    let paramString = ''
+    _.forEach(params, (val, key) => {
+      paramString += `${key}=${val}&`
+    })
+    const finalPath = `${path}?${paramString}`
+    return paramString.length > 0 ? finalPath.substring(0, finalPath.length - 1) : path
   }
 }
 

--- a/model/index.spec.js
+++ b/model/index.spec.js
@@ -1,0 +1,27 @@
+const Model = require('./')
+const Context = require('../test/factories/vscode/context')
+
+const context = Context.build()
+context.globalState = {
+  get: jest.fn().mockReturnValue('val')
+}
+
+describe('#model', () => {
+  const model = new Model(context)
+  describe('_addParams', () => {
+    test('it should add params as expected', () => {
+      const urlWithParams = model._addParams('www.myurl.com', {q: 2, track: '123'})
+      expect(urlWithParams).toBe('www.myurl.com?q=2&track=123')
+    })
+
+    test('it should return original path if no ', () => {
+      const urlWithParams = model._addParams('www.myurl.com', {})
+      expect(urlWithParams).toBe('www.myurl.com')
+    })
+
+    test('it should remove trailing slashes', () => {
+      const urlWithParams = model._addParams('www.myurl.com/', {q: 2, track: '123'})
+      expect(urlWithParams).toBe('www.myurl.com?q=2&track=123')
+    })
+  })
+})

--- a/model/iterations/index.js
+++ b/model/iterations/index.js
@@ -1,19 +1,21 @@
 const Model = require('../')
 
 class PtIterations extends Model{
-  constructor(context) {
+  constructor(context, maxIterations) {
     super(context)
     this._baseIterationsPath = `${this._baseApiPath}/iterations`
+    this._maxIterations = maxIterations
   }
 
   get _endpoints() {
     return {
-      getIterations: scope => `${this._baseIterationsPath}?scope=${scope}`,
+      getIterations: scope => this._addParams(this._baseIterationsPath, {scope, offset: (0 - this._maxIterations), limit: this._maxIterations + 1}),
       getIterationCycleTime: iterationNumber => `${this._baseIterationsPath}/${iterationNumber}/analytics/cycle_time_details`
     }
   }
 
-  getIterations(scope = '') {
+  getIterations(scope = 'done_current') {
+    if(!['done', 'current', 'backlog', 'current_backlog', 'done_current'].includes(scope)) throw new Error('Invalid scope')
     return this._fetch('get', this._endpoints.getIterations(scope))
   }
 

--- a/model/iterations/index.js
+++ b/model/iterations/index.js
@@ -8,14 +8,21 @@ class PtIterations extends Model{
 
   get _endpoints() {
     return {
-      getIterations: (scope, maxIterations) => this._addParams(this._baseIterationsPath, {scope, offset: (0 - maxIterations), limit: maxIterations + 1}),
+      getDoneIterations: (scope, maxIterations) => this._addParams(this._baseIterationsPath, {scope, offset: (0 - maxIterations), limit: maxIterations + 1}),
+      getIterations: params => this._addParams(this._baseIterationsPath, params),
       getIterationCycleTime: iterationNumber => `${this._baseIterationsPath}/${iterationNumber}/analytics/cycle_time_details`
     }
   }
 
-  getIterations(scope = 'done_current', maxIterations) {
+  getDoneIterations(scope = 'done_current', maxIterations) {
     if(!['done', 'current', 'backlog', 'current_backlog', 'done_current'].includes(scope)) throw new Error('Invalid scope')
-    return this._fetch('get', this._endpoints.getIterations(scope, maxIterations))
+    if(!scope.includes('done')) return this.getIterations({scope})
+    return this._fetch('get', this._endpoints.getDoneIterations(scope, maxIterations))
+  }
+
+  getIterations(params) {
+    if(params.scope && !['current', 'backlog', 'current_backlog'].includes(params.scope)) throw new Error('Invalid scope')
+    return this._fetch('get', this._endpoints.getIterations(params))
   }
 
   getIterationCycleTime(iterationNumber) {

--- a/model/iterations/index.js
+++ b/model/iterations/index.js
@@ -1,22 +1,21 @@
 const Model = require('../')
 
 class PtIterations extends Model{
-  constructor(context, maxIterations) {
+  constructor(context) {
     super(context)
     this._baseIterationsPath = `${this._baseApiPath}/iterations`
-    this._maxIterations = maxIterations
   }
 
   get _endpoints() {
     return {
-      getIterations: scope => this._addParams(this._baseIterationsPath, {scope, offset: (0 - this._maxIterations), limit: this._maxIterations + 1}),
+      getIterations: (scope, maxIterations) => this._addParams(this._baseIterationsPath, {scope, offset: (0 - maxIterations), limit: maxIterations + 1}),
       getIterationCycleTime: iterationNumber => `${this._baseIterationsPath}/${iterationNumber}/analytics/cycle_time_details`
     }
   }
 
-  getIterations(scope = 'done_current') {
+  getIterations(scope = 'done_current', maxIterations) {
     if(!['done', 'current', 'backlog', 'current_backlog', 'done_current'].includes(scope)) throw new Error('Invalid scope')
-    return this._fetch('get', this._endpoints.getIterations(scope))
+    return this._fetch('get', this._endpoints.getIterations(scope, maxIterations))
   }
 
   getIterationCycleTime(iterationNumber) {

--- a/model/iterations/index.spec.js
+++ b/model/iterations/index.spec.js
@@ -1,0 +1,61 @@
+jest.mock('../')
+const PtIteration = require('./')
+const Model = require('../')
+const Context = require('../../test/factories/vscode/context')
+
+const context = Context.build()
+const IterationResource = new PtIteration(context, 30)
+
+
+describe('#iterations', () => {
+  describe('_endpoints', () => {
+    const modelMockInstance = Model.mock.instances[0]
+    modelMockInstance._addParams = jest.fn().mockReturnValue('apiPath?params=7')
+
+    afterEach(() => Model.mockClear())
+
+    test('it should have all iteration endpoints', () => {
+      const endpoints = IterationResource._endpoints
+      expect(endpoints).toHaveProperty('getIterations')
+      expect(endpoints).toHaveProperty('getIterationCycleTime')
+      endpoints.getIterations('done')
+      expect(modelMockInstance._addParams).toHaveBeenCalledTimes(1)
+      expect(modelMockInstance._addParams.mock.calls[0][0]).toEqual(IterationResource._baseIterationsPath);
+      expect({
+        scope: 'done',
+        offset: -30,
+        limit: 31
+      }).toMatchObject(modelMockInstance._addParams.mock.calls[0][1]);
+      const cyclePath = endpoints.getIterationCycleTime(1)
+      expect(cyclePath).toBe(`${IterationResource._baseIterationsPath}/1/analytics/cycle_time_details`)
+    })
+  })
+
+  describe('getIterations', () => {
+    const modelMockInstance = Model.mock.instances[0]
+    modelMockInstance._addParams = jest.fn().mockReturnValue('apiPath?params=7')
+
+    afterEach(() => Model.mockClear())
+
+    test('it should raise error if scope is invalid', () => {
+      expect(() => IterationResource.getIterations('invalid')).toThrowError('Invalid scope')
+    })
+
+    test('it should call fetch with the right params', async () => {
+      await IterationResource.getIterations('current')
+      expect(modelMockInstance._fetch).toHaveBeenCalledWith('get', 'apiPath?params=7')
+    })
+  })
+
+  describe('getIterationCycleTime', () => {
+    const modelMockInstance = Model.mock.instances[0]
+    modelMockInstance._baseApiPath = 'apiPath'
+
+    afterEach(() => Model.mockClear())
+
+    test('it should call fetch with the right params', async () => {
+      await IterationResource.getIterationCycleTime(1)
+      expect(modelMockInstance._fetch).toHaveBeenCalledWith('get', 'undefined/iterations/1/analytics/cycle_time_details')
+    })
+  })
+})

--- a/model/iterations/index.spec.js
+++ b/model/iterations/index.spec.js
@@ -4,7 +4,7 @@ const Model = require('../')
 const Context = require('../../test/factories/vscode/context')
 
 const context = Context.build()
-const IterationResource = new PtIteration(context, 30)
+const IterationResource = new PtIteration(context)
 
 
 describe('#iterations', () => {
@@ -17,8 +17,18 @@ describe('#iterations', () => {
     test('it should have all iteration endpoints', () => {
       const endpoints = IterationResource._endpoints
       expect(endpoints).toHaveProperty('getIterations')
+      expect(endpoints).toHaveProperty('getDoneIterations')
       expect(endpoints).toHaveProperty('getIterationCycleTime')
-      endpoints.getIterations('done')
+      endpoints.getIterations({scope: 'current', limit: 10})
+      expect(modelMockInstance._addParams).toHaveBeenCalledTimes(1)
+      expect({
+        scope: 'current',
+        limit: 10
+      }).toMatchObject(modelMockInstance._addParams.mock.calls[0][1]);
+
+      modelMockInstance._addParams.mockClear()
+
+      endpoints.getDoneIterations('done', 30)
       expect(modelMockInstance._addParams).toHaveBeenCalledTimes(1)
       expect(modelMockInstance._addParams.mock.calls[0][0]).toEqual(IterationResource._baseIterationsPath);
       expect({
@@ -38,11 +48,34 @@ describe('#iterations', () => {
     afterEach(() => Model.mockClear())
 
     test('it should raise error if scope is invalid', () => {
-      expect(() => IterationResource.getIterations('invalid')).toThrowError('Invalid scope')
+      expect(() => IterationResource.getIterations({scope: 'done'})).toThrowError('Invalid scope')
     })
 
     test('it should call fetch with the right params', async () => {
       await IterationResource.getIterations('current')
+      expect(modelMockInstance._fetch).toHaveBeenCalledWith('get', 'apiPath?params=7')
+    })
+  })
+
+  describe('getDoneIterations', () => {
+    const modelMockInstance = Model.mock.instances[0]
+    modelMockInstance._addParams = jest.fn().mockReturnValue('apiPath?params=7')
+
+    afterEach(() => Model.mockClear())
+
+    test('it should call getIterations if scope does not include done', () => {
+      IterationResource.getIterations = jest.fn()
+      IterationResource.getDoneIterations('current')
+      expect(IterationResource.getIterations).toHaveBeenCalledTimes(1)
+    })
+
+    test('it should raise error if scope is invalid', () => {
+      expect(() => IterationResource.getDoneIterations('invalid')).toThrowError('Invalid scope')
+    })
+
+
+    test('it should call fetch with the right params', async () => {
+      await IterationResource.getDoneIterations('done')
       expect(modelMockInstance._fetch).toHaveBeenCalledWith('get', 'apiPath?params=7')
     })
   })

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -24,7 +24,7 @@ const activate = async context => {
 
   const statusBarItem = createPTStatusBarItem()
 
-  const cycleTimeProvider = new CycleTimeDataProvider(context, {length: 6, unit: 'months'})
+  const cycleTimeProvider = new CycleTimeDataProvider(context, {length: 6, unit: 'months'}, 'done_current')
   const storyInfoProvider = new StoryInfoDataProvider(context)
   const cpProvider = new ControlPanelDataProvider(context, statusBarItem)
 

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -42,7 +42,7 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.internal.showCommandsQuickPick, () => commandRepo.showAllCommands(context)),
     commands.registerCommand(commandRepo.commands.internal.registerToken, () => commandRepo.registerToken(context)),
     commands.registerCommand(commandRepo.commands.internal.registerProjectID, () => commandRepo.registerProjectID(context)),
-    commands.registerCommand(commandRepo.commands.statistics.cycleTime, (context, scope, iteration_number) =>  commandRepo.showStats(context, scope, iteration_number)),
+    commands.registerCommand(commandRepo.commands.statistics.cycleTime, (context, iteration) =>  commandRepo.showStats(context, iteration)),
     commands.registerCommand(commandRepo.commands.storyState.refreshStateView, () => commandRepo.refreshStateView(context, storyInfoProvider)),
     commands.registerCommand(commandRepo.commands.storyState.deliverTask, taskTreeeItem => commandRepo.deliverTask(taskTreeeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unDeliverTask, taskTreeItem => commandRepo.undeliverTask(taskTreeItem, context)),

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -24,7 +24,7 @@ const activate = async context => {
 
   const statusBarItem = createPTStatusBarItem()
 
-  const cycleTimeProvider = new CycleTimeDataProvider(context, {length: 6, unit: 'months'}, 'done_current')
+  const cycleTimeProvider = new CycleTimeDataProvider(context, 6, 'done_current')
   const storyInfoProvider = new StoryInfoDataProvider(context)
   const cpProvider = new ControlPanelDataProvider(context, statusBarItem)
 


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where newer iterations do not show up in member cycle view

#### How should this be manually tested?
Open Member Cycle View. Newer iterations for at most the last 6 months should show up.

#### Any background context you want to provide?
API path `get /projects/{project_id}/iterations` returns the oldest iterations first. Statistics are not available for iterations older than 6 months.

#### Screenshots (if appropriate)

<img width="362" alt="Screen Shot 2019-05-15 at 23 59 02" src="https://user-images.githubusercontent.com/19430730/57809079-759ee900-776d-11e9-8e3e-29fa5f5d506e.png">

#### Questions:
n/a
