### PR TITLE
Refresh story view on check out and linking a story

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,2 +1,4 @@
 exclude_paths:
   - '**.spec.js'
+  - '__mocks__/**'
+  - 'test/**'

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -44,5 +44,8 @@ module.exports = {
     Collapsed: 1,
     None: 2
   },
-  EventEmitter: class {}
+  EventEmitter: class {},
+  commands: {
+    executeCommand: jest.fn()
+  }
 }

--- a/lib/commands/linkStory.js
+++ b/lib/commands/linkStory.js
@@ -10,7 +10,7 @@ const {generateQuickPickArray, extractIdFromQuickPick} = require('../adapters/ge
 const validateStoryID = (context, isARepo) =>
   isARepo ? validate('linkStory', context) : true
 
-const linkStory = async context => {
+const linkStory = async (context, storyInfoProvider) => {
   const isARepo = context.workspaceState.get(common.globals.isARepo)
   const shouldLink = await validateStoryID(context, isARepo)
   if(!shouldLink) return rebounds('failedLinkedStory', context)
@@ -41,7 +41,7 @@ const linkStory = async context => {
   const branch = isARepo ? await getActiveBranch() : undefined
 
   await setState(context, branch, storyID)
-  return rebounds('linkedStory', context)
+  return rebounds('linkedStory', context, '', [context, storyInfoProvider])
 }
 
 module.exports = {

--- a/lib/commands/linkStory.spec.js
+++ b/lib/commands/linkStory.spec.js
@@ -34,7 +34,7 @@ describe('#linkStory', () => {
     validate.mockReturnValue(true)
     vscode.window.showQuickPick = jest.fn().mockResolvedValue('do chore - 2')
     getActiveBranch.mockReturnValue('activeBranch')
-    await linkStory(contex, {})
+    await linkStory(context, {})
     expect(rebounds.mock.calls[0][0]).toBe('linkedStory')
   })
 

--- a/lib/commands/linkStory.spec.js
+++ b/lib/commands/linkStory.spec.js
@@ -3,7 +3,6 @@ jest.mock('../helpers/state')
 jest.mock('../validation/validate')
 jest.mock('../validation/rebounds')
 jest.mock('../../model/iterations')
-
 const vscode = require('vscode')
 const rebounds = require('../validation/rebounds')
 const {getActiveBranch} = require('../helpers/git')
@@ -13,7 +12,9 @@ const Context = require('../../test/factories/vscode/context')
 const PtIterations = require('../../model/iterations')
 
 const context = Context.build()
-
+const storyDataProvider = {
+  refresh: jest.fn()
+}
 describe('#linkStory', () => {
   beforeEach(() => {
     PtIterations.mockImplementation(() => ({
@@ -34,25 +35,25 @@ describe('#linkStory', () => {
     validate.mockReturnValue(true)
     vscode.window.showQuickPick = jest.fn().mockResolvedValue('do chore - 2')
     getActiveBranch.mockReturnValue('activeBranch')
-    await linkStory(context, {})
+    await linkStory(context, storyDataProvider)
     expect(rebounds.mock.calls[0][0]).toBe('linkedStory')
     expect(rebounds.mock.calls[0][1]).toMatchObject(context)
     expect(rebounds.mock.calls[0][2]).toBeFalsy()
-    expect(rebounds.mock.calls[0][3]).toMatchObject([context, {}])
+    expect(rebounds.mock.calls[0][3]).toMatchObject([context, storyDataProvider])
   })
 
   it('should rebound failedLinkedStory if default branch', async () => {
     const _context = Context.build()
     _context.workspaceState.get = jest.fn(() => true)
     validate.mockReturnValue(false)
-    await linkStory(_context, {})
+    await linkStory(_context, storyDataProvider)
     expect(rebounds.mock.calls[0][0]).toBe('failedLinkedStory')
     expect(rebounds.mock.calls[0][1]).toMatchObject(_context)
   })
 
   it('should return void if no story id is entered', async () => {
     vscode.window.showQuickPick = jest.fn(() => undefined)
-    const linkedStory = await linkStory(context, {})
+    const linkedStory = await linkStory(context, storyDataProvider)
     expect(linkedStory).toBeUndefined()
   })
 
@@ -61,7 +62,7 @@ describe('#linkStory', () => {
       getIterations: jest.fn().mockRejectedValue('invalid_authentication')
     }))
     vscode.window.showErrorMessage = jest.fn().mockResolvedValue(undefined)
-    const linked = await linkStory(context, {})
+    const linked = await linkStory(context, storyDataProvider)
     expect(linked).toBe(undefined)
   })
 })

--- a/lib/commands/linkStory.spec.js
+++ b/lib/commands/linkStory.spec.js
@@ -34,7 +34,7 @@ describe('#linkStory', () => {
     validate.mockReturnValue(true)
     vscode.window.showQuickPick = jest.fn().mockResolvedValue('do chore - 2')
     getActiveBranch.mockReturnValue('activeBranch')
-    await linkStory(context)
+    await linkStory(contex, {})
     expect(rebounds.mock.calls[0][0]).toBe('linkedStory')
   })
 
@@ -42,13 +42,13 @@ describe('#linkStory', () => {
     const _context = Context.build()
     _context.workspaceState.get = jest.fn(() => true)
     validate.mockReturnValue(false)
-    await linkStory(_context)
+    await linkStory(_context, {})
     expect(rebounds.mock.calls[0][0]).toBe('failedLinkedStory')
   })
 
   it('should return void if no story id is entered', async () => {
     vscode.window.showQuickPick = jest.fn(() => undefined)
-    const linkedStory = await linkStory(context)
+    const linkedStory = await linkStory(context, {})
     expect(linkedStory).toBeUndefined()
   })
 
@@ -57,7 +57,7 @@ describe('#linkStory', () => {
       getIterations: jest.fn().mockRejectedValue('invalid_authentication')
     }))
     vscode.window.showErrorMessage = jest.fn().mockResolvedValue(undefined)
-    const linked = await linkStory(context)
+    const linked = await linkStory(context, {})
     expect(linked).toBe(undefined)
   })
 })

--- a/lib/commands/linkStory.spec.js
+++ b/lib/commands/linkStory.spec.js
@@ -36,6 +36,9 @@ describe('#linkStory', () => {
     getActiveBranch.mockReturnValue('activeBranch')
     await linkStory(context, {})
     expect(rebounds.mock.calls[0][0]).toBe('linkedStory')
+    expect(rebounds.mock.calls[0][1]).toMatchObject(context)
+    expect(rebounds.mock.calls[0][2]).toBeFalsy()
+    expect(rebounds.mock.calls[0][3]).toMatchObject([context, {}])
   })
 
   it('should rebound failedLinkedStory if default branch', async () => {
@@ -44,6 +47,7 @@ describe('#linkStory', () => {
     validate.mockReturnValue(false)
     await linkStory(_context, {})
     expect(rebounds.mock.calls[0][0]).toBe('failedLinkedStory')
+    expect(rebounds.mock.calls[0][1]).toMatchObject(_context)
   })
 
   it('should return void if no story id is entered', async () => {

--- a/lib/commands/refreshMemberCycleView.spec.js
+++ b/lib/commands/refreshMemberCycleView.spec.js
@@ -1,6 +1,6 @@
 const refreshMemberCycleView = require('./refreshMemberCycleView')
 
-describe('3refreshMemberCycleView', () => {
+describe('refreshMemberCycleView', () => {
   test('calls refresh on data provider', () => {
     const dataProvider = {
       refresh: jest.fn()

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -1,6 +1,6 @@
 const {commands, window} = require('vscode')
 const {common} = require('../commands/common')
-const {validate, validateStory} = require('../validation/validate')
+const {validate} = require('../validation/validate')
 const rebound = require('../validation/rebounds')
 const commandStrings = require('./commands')
 

--- a/lib/commands/showAllCommands.js
+++ b/lib/commands/showAllCommands.js
@@ -6,25 +6,29 @@ const getAllKeys = require('../adapters/getAllKeys')
 
 module.exports = async (context, storyInfoProvider) => {
   const textToCommandMapping = {
-    "$(triangle-right)\tStart Story": {
-      command: storyState.startStory,
-      args: [context]
+    storyState: {
+      "$(triangle-right)\tStart Story": {
+        command: storyState.startStory,
+        args: [context]
+      },
+      "$(primitive-square)\tStop Story": {
+        command: storyState.stopStory,
+        args: [context]
+      },
+      "$(check)\tFinish Story": {
+        command: storyState.finishStory,
+        args: [context]
+      },
+      "$(briefcase)\tDeliver Story": {
+        command: storyState.deliverStory,
+        args: [context]
+      }
     },
-    "$(primitive-square)\tStop Story": {
-      command: storyState.stopStory,
-      args: [context]
-    },
-    "$(check)\tFinish Story": {
-      command: storyState.finishStory,
-      args: [context]
-    },
-    "$(briefcase)\tDeliver Story": {
-      command: storyState.deliverStory,
-      args: [context]
-    },
-    "$(link)\tLink Story": {
-      command: workState.linkStory,
-      args: [context, storyInfoProvider]
+    workState: {
+      "$(link)\tLink Story": {
+        command: workState.linkStory,
+        args: [context, storyInfoProvider]
+      }
     }
   }
   
@@ -32,13 +36,23 @@ module.exports = async (context, storyInfoProvider) => {
 
   const state = getState(context)
   const placeHolder = state.story ? `(${state.story}) ${state.storyDetails.name}` : `Pick action`
-  const allCommands = getAllKeys(textToCommandMapping)
+  
+  const commandTypes = Object.keys(textToCommandMapping)
+  const mashedCommands = {}
+  const allCommands = commandTypes.reduce((prev, current, index) => {
+    if(index === 1) {
+      Object.assign(mashedCommands, textToCommandMapping[prev], textToCommandMapping[current])
+      return Object.keys(textToCommandMapping[prev]).concat(Object.keys(textToCommandMapping[current]))
+    }
+    Object.assign(mashedCommands, textToCommandMapping[current])
+    return prev.concat(Object.keys(textToCommandMapping[current]))
+  })
 
   const relevantCommands = state.story ? allCommands
    : _.difference(allCommands, getCommands('storyState'))
 
   const pickedItem = window.showQuickPick(relevantCommands, { canPickMany: false, ignoreFocusOut: true, placeHolder})
   pickedItem.then(action =>
-    commands.executeCommand(textToCommandMapping[action].command, ...textToCommandMapping[action].args)
+    commands.executeCommand(mashedCommands[action].command, ...mashedCommands[action].args)
   )
 }

--- a/lib/commands/showAllCommands.js
+++ b/lib/commands/showAllCommands.js
@@ -1,10 +1,10 @@
 const {window, commands} = require("vscode")
 const _ = require('lodash')
 const {getState} = require("../helpers/state")
-const {storyState, workState, statistics} = require("./commands").commands
+const {storyState, workState} = require("./commands").commands
 const getAllKeys = require('../adapters/getAllKeys')
 
-module.exports = async context => {
+module.exports = async (context, storyInfoProvider) => {
   const textToCommandMapping = {
     "$(triangle-right)\tStart Story": {
       command: storyState.startStory,
@@ -24,7 +24,7 @@ module.exports = async context => {
     },
     "$(link)\tLink Story": {
       command: workState.linkStory,
-      args: [context]
+      args: [context, storyInfoProvider]
     }
   }
   

--- a/lib/commands/showAllCommands.spec.js
+++ b/lib/commands/showAllCommands.spec.js
@@ -1,0 +1,54 @@
+jest.mock('../helpers/state')
+const vscode = require('vscode')
+const showAllCommands = require('./showAllCommands')
+const stateHelper = require('../helpers/state')
+const Context = require('../../test/factories/vscode/context')
+
+const storyInfoProvider = {
+  refresh: jest.fn()
+}
+const context = Context.build()
+
+describe('#showAllCommands', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  beforeEach(() => {
+    vscode.window.showQuickPick = jest.fn().mockResolvedValue('$(triangle-right)\tStart Story')
+  })
+
+  test('should show all commands if a story is available', async () => {
+    stateHelper.getState.mockReturnValue({
+      story: 123,
+      storyDetails: {
+        name: 'test story'
+      }
+    })
+    await showAllCommands(context, storyInfoProvider)
+    const expectedCommands = ['$(triangle-right)\tStart Story', '$(primitive-square)\tStop Story', '$(check)\tFinish Story', '$(briefcase)\tDeliver Story', '$(link)\tLink Story']
+    const calledCommands = vscode.window.showQuickPick.mock.calls[0][0]
+    expect(expectedCommands).toMatchObject(calledCommands)
+  })
+
+  test('should show a subset of commands if story is unavailable', async () => {
+    stateHelper.getState.mockReturnValue({
+      story: undefined
+    })
+    await showAllCommands(context, storyInfoProvider)
+    const expectedCommands = ['$(link)\tLink Story']
+    const calledCommands = vscode.window.showQuickPick.mock.calls[0][0]
+    expect(expectedCommands).toMatchObject(calledCommands)
+  })
+
+  test('should execute picked command', async () => {
+    stateHelper.getState.mockReturnValue({
+      story: 123,
+      storyDetails: {
+        name: 'test story'
+      }
+    })
+    await showAllCommands(context, storyInfoProvider)
+    expect(vscode.commands.executeCommand).toBeCalledTimes(1)
+    expect(vscode.commands.executeCommand.mock.calls[0][0]).toBe('pivotaly.startStory')
+    expect(vscode.commands.executeCommand.mock.calls[0][1]).toMatchObject(context)
+  })
+})

--- a/lib/validation/rebounds.js
+++ b/lib/validation/rebounds.js
@@ -17,6 +17,7 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
     case 'defaultBranch':
       wipeState(ctx)
       window.showInformationMessage(msg || 'Switch to a feature branch to start working on a story')
+      commands.executeCommand(commandRepo.commands.storyState.refreshStateView, args)      
       break
     case 'story':
       window.showWarningMessage(msg || 'Invalid story ID.')
@@ -25,6 +26,7 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
       break
     case 'storyChange':
       window.showInformationMessage(msg || `Changed story to ${story}`)
+      commands.executeCommand(commandRepo.commands.storyState.refreshStateView, args)
       break
     case 'invalidBranchName':
       window.showWarningMessage(msg || 'Could not detect a story id from branch name. You may need to link a story manually.')
@@ -59,6 +61,7 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
       break
     case 'linkedStory':
       window.showInformationMessage(msg || `Successfully linked story ${story}`)
+      commands.executeCommand(commandRepo.commands.storyState.refreshStateView, args)
       break
     case 'failedLinkedStory':
       window.showErrorMessage(msg || `Could not link story. You are using a protected branch`)

--- a/lib/validation/validate.js
+++ b/lib/validation/validate.js
@@ -31,9 +31,9 @@ const validate = async (elementToValidate, context, rebound = false, failMessage
   })
 }
 
-const validateStory = async context => {
+const validateStory = async (context, storyInfoProvider) => {
   const isFeatureBranch = await isBranchDefault()
-  if(!isFeatureBranch) return rebounds('defaultBranch', context)
+  if(!isFeatureBranch) return rebounds('defaultBranch', context, '', [context, storyInfoProvider])
 
   const branchChanged = await didBranchChange(context)
   if(branchChanged) {
@@ -41,7 +41,7 @@ const validateStory = async context => {
     const storyID = await getStoryID(context, currentBranch)
     if (storyID) {
       await setState(context, currentBranch, storyID)
-      return rebounds("storyChange", context)
+      return rebounds('storyChange', context, '', [context, storyInfoProvider])
     }
     return rebounds('invalidBranchName', context)
   }

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -37,8 +37,8 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.storyState.stopStory, () => commandRepo.stopStory(context)),
     commands.registerCommand(commandRepo.commands.storyState.finishStory, () => commandRepo.finishStory(context)),
     commands.registerCommand(commandRepo.commands.storyState.deliverStory, () => commandRepo.deliverStory(context)),
-    commands.registerCommand(commandRepo.commands.workState.linkStory, () => commandRepo.linkStory(context)),
-    commands.registerCommand(commandRepo.commands.internal.showCommandsQuickPick, () => commandRepo.showAllCommands(context)),
+    commands.registerCommand(commandRepo.commands.workState.linkStory, () => commandRepo.linkStory(context, storyInfoProvider)),
+    commands.registerCommand(commandRepo.commands.internal.showCommandsQuickPick, () => commandRepo.showAllCommands(context, storyInfoProvider)),
     commands.registerCommand(commandRepo.commands.internal.registerToken, () => commandRepo.registerToken(context, storyInfoProvider)),
     commands.registerCommand(commandRepo.commands.internal.registerProjectID, () => commandRepo.registerProjectID(context, storyInfoProvider)),
     commands.registerCommand(commandRepo.commands.statistics.cycleTime, (context, iteration) =>  commandRepo.showStats(context, iteration)),
@@ -53,7 +53,7 @@ const activate = async context => {
 
   validate('token', context).then(_didValidationSucceed => {
     validate('projectID', context, true).then(_didProjectValidationSucceed => {
-      if (isARepo) validateStory(context)
+      if (isARepo) validateStory(context, storyInfoProvider)
       else validate('story', context, true).then(didSucceed => {}, didFail => {})
     }, _didProjectValidationSucceed => {})
   }, _didValidationSucceed => {})
@@ -62,7 +62,7 @@ const activate = async context => {
     unlinkGitEmit(context, rootPath)
     const gitEvents = new GitEvents()
     gitEvents.on('checkout', () => {
-      validateStory(context)
+      validateStory(context, storyInfoProvider)
     })
     listenForCheckOut(gitEvents)
   }


### PR DESCRIPTION
#### What does this PR do?
Refreshes story view after linking a story or checking out to a new branch
#### How should this be manually tested?
- Start the extension and check out to a new branch or link a new story to existing branch
- The story information view should reflect the changes
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a