### PR TITLE
Add reload icon and command on member cycle time view

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,14 @@
           "light": "images/other/check-square-regular.svg",
           "dark": "images/other/check-square-regular-light.svg"
         }
+      },
+      {
+        "command": "pivotaly.refreshMemberCycleView",
+        "title": "Reload Member Cycle",
+        "icon": {
+          "light": "images/octicons/sync.svg",
+          "dark": "images/octicons/sync-light.svg"
+        }
       }
     ],
     "configuration": [
@@ -189,6 +197,11 @@
           "command": "pivotaly.refreshStateView",
           "when": "view == pivotaly.view.storyinfo",
           "group": "navigation@5"
+        },
+        {
+          "command": "pivotaly.refreshMemberCycleView",
+          "when": "view == pivotaly.view.membercycle",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
#### What does this PR do?
Adds reload icon and command to member cycle view
#### How should this be manually tested?
- Open extension
- Member cycle view should have a reload icon in the title bar that refreshes cycle time on click
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
<img width="378" alt="Screen Shot 2019-05-20 at 20 37 02" src="https://user-images.githubusercontent.com/19430730/58040798-1101d680-7b3f-11e9-8515-0424f0600b37.png">

#### Questions:
n/a
