### PR TITLE
Ft dont run extension till workspace is open 166119035

### DIFF
--- a/lib/helpers/git.js
+++ b/lib/helpers/git.js
@@ -1,8 +1,8 @@
 const {workspace} = require("vscode")
-const simpleGit = require("simple-git")(workspace.workspaceFolders[0].uri.fsPath)
+const simpleGit = require("simple-git")
 
 const getActiveBranch = () => new Promise((resolve, reject) => {
-  simpleGit.branchLocal((err, branchSummary) => {
+  simpleGit(workspace.workspaceFolders[0].uri.fsPath).branchLocal((err, branchSummary) => {
     !!err ? reject(err) : resolve(branchSummary.current)
   })
 })

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -15,6 +15,8 @@ const GitEvents = require('../lib/events/gitEvents')
 
 
 const activate = async context => {
+  if(workspace.workspaceFolders === undefined) return
+
   await refreshState(context)
   const rootPath = (workspace.workspaceFolders && workspace.workspaceFolders[0].uri.fsPath) || workspace.rootPath
   const isARepo = rootPath ? await isRepo(rootPath) : false


### PR DESCRIPTION
#### What does this PR do?
Ascertains a workspace is open before running extension
#### How should this be manually tested?
- No error should be displayed when you open vs code without opening a folder
#### Any background context you want to provide?
The extension relies on workspaces to work. Workspaces are linked to pivotal tracker projects.
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a