### PR TITLE
Add blockers from story info 165934370

### DIFF
--- a/images/octicons/plus-light.svg
+++ b/images/octicons/plus-light.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16"><path fill-rule="evenodd" fill="#FFFFFF" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"/></svg>

--- a/images/octicons/plus.svg
+++ b/images/octicons/plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16"><path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"/></svg>

--- a/lib/commands/addBlocker.js
+++ b/lib/commands/addBlocker.js
@@ -1,0 +1,5 @@
+const {window} = require('vscode')
+
+module.exports = () => {
+  window.showInformationMessage('Adding blocker')
+}

--- a/lib/commands/addBlocker.js
+++ b/lib/commands/addBlocker.js
@@ -1,5 +1,25 @@
 const {window} = require('vscode')
+const Blocker = require('../../model/blockers')
+const rebounds = require('../validation/rebounds')
+const {getState} = require('../helpers/state')
 
-module.exports = () => {
-  window.showInformationMessage('Adding blocker')
+module.exports = async (taskTreeItem, context) => {
+  const description = await window.showInputBox({
+    prompt: 'Enter blocker description'
+  })
+  if(!description) return
+  const storyId = getState(context).story
+  const BlockerResource = new Blocker(context, storyId, null)
+  let creation
+  try{
+    creation = await BlockerResource.createBlocker(description)
+  } catch (error) {
+    return rebounds('failedAddBlocker')
+  }
+  if(creation.res.statusCode === 200) {
+    await rebounds('addBlocker', context)
+    taskTreeItem.dataProvider.refresh()
+    return
+  }
+  return rebounds('failedAddBlocker')
 }

--- a/lib/commands/addBlocker.spec.js
+++ b/lib/commands/addBlocker.spec.js
@@ -1,0 +1,45 @@
+jest.mock('../validation/rebounds')
+jest.mock('../../model/blockers')
+jest.mock('../helpers/state')
+const vscode = require('vscode')
+const addBlocker = require('./addBlocker')
+const rebounds = require('../validation/rebounds')
+const Blocker = require('../../model/blockers')
+const {getState} = require('../helpers/state')
+
+let taskTreeItem
+describe('#addBlocker', () => {
+  beforeEach(() => {
+    rebounds.mockImplementation(jest.fn())
+    taskTreeItem = {
+      dataProvider: {
+        refresh: jest.fn()
+      }
+    }
+    getState.mockReturnValue({story: 1})
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  test('should return undefined if no descriptions is provided', async () => {
+    vscode.window.showInputBox = jest.fn().mockResolvedValue(undefined)
+    const added = await addBlocker({}, {})
+    expect(added).toBe(undefined)
+  })
+
+  test('should refresh view if blocker is created successfully', async () => {
+    vscode.window.showInputBox = jest.fn().mockResolvedValue('new blocker description')
+
+    Blocker.mockImplementationOnce(() => ({
+      createBlocker: jest.fn().mockResolvedValue({
+        res: {
+          statusCode: 200
+        }
+      })
+    }))
+
+    await addBlocker(taskTreeItem, {})
+    expect(taskTreeItem.dataProvider.refresh).toBeCalledTimes(1)
+
+  })
+})

--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -7,6 +7,7 @@ exports.commands = {
     refreshStateView: 'pivotaly.refreshStateView',
     refreshMemberCycleView: 'pivotaly.refreshMemberCycleView',
     deliverTask: 'pivotaly.deliverTask',
+    addBlocker: 'pivotaly.addBlocker',
     unDeliverTask: 'pivotaly.unDeliverTask',
     resolveBlocker: 'pivotaly.resolveBlocker',
     unResolveBlocker: 'pivotaly.unResolveBlocker',

--- a/lib/commands/deliverTask.spec.js
+++ b/lib/commands/deliverTask.spec.js
@@ -28,7 +28,6 @@ describe('#deliverTask', () => {
       PtTasks.mockImplementationOnce(() => ({
         updateTask: () => ({res: {statusCode: 200}})
       }))
-      taskTreeItem.taskOrBlockerContext = 'complete-1'
       storyInfoProvider.refresh = jest.fn()
       await deliverTask(taskTreeItem, context)
       expect(rebounds).toBeCalledWith('deliveredTask', context)
@@ -39,7 +38,6 @@ describe('#deliverTask', () => {
       PtTasks.mockImplementationOnce(() => ({
         updateTask: () => ({res: {statusCode: 201}})
       }))
-      taskTreeItem.taskOrBlockerContext = 'complete-1'
       storyInfoProvider.refresh = jest.fn()
       await deliverTask(taskTreeItem, context)
       expect(rebounds).toBeCalledWith('failedDeliveredTask')
@@ -49,7 +47,6 @@ describe('#deliverTask', () => {
       PtTasks.mockImplementationOnce(() => ({
         updateTask: jest.fn().mockRejectedValue('invalid_authentication')
       }))
-      taskTreeItem.taskOrBlockerContext = 'complete-1'
       storyInfoProvider.refresh = jest.fn()
       await deliverTask(taskTreeItem, context)
       expect(rebounds).toBeCalledWith('failedDeliveredTask')

--- a/lib/commands/deliverTask.spec.js
+++ b/lib/commands/deliverTask.spec.js
@@ -9,11 +9,13 @@ const PtTasks = require('../../model/tasks')
 
 const context = Context.build()
 const storyInfoProvider = new StoryInfoDataProvider(context)
-const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider)
+const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
 
 describe('#deliverTask', () => {
   it('should fail if taskTreeItem lacks an itemid', () => {
-    deliverTask(taskTreeItem, context)
+    const taskTree = new TaskTreeItem('My task', storyInfoProvider, 'item-2')
+    delete taskTree.itemId
+    deliverTask(taskTree, context)
     expect(rebounds).toBeCalledWith('failedDeliveredTask')
   })
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -10,6 +10,7 @@ const registerProjectID = require("./registerProjectID")
 const showStats = require("./showStats")
 const deliverTask = require('./deliverTask')
 const undeliverTask = require('./undeliverTask')
+const addBlocker = require('./addBlocker')
 const resolveBlocker = require('./resolveBlocker')
 const unresolveBlocker = require('./unresolveBlocker')
 const refreshStateView = require('./refreshStateView')
@@ -29,6 +30,7 @@ module.exports = {
   showStats,
   deliverTask,
   undeliverTask,
+  addBlocker,
   resolveBlocker,
   unresolveBlocker,
   refreshStateView,

--- a/lib/commands/resolveBlocker.spec.js
+++ b/lib/commands/resolveBlocker.spec.js
@@ -23,7 +23,6 @@ describe('#resolveBlocker', () => {
     PtBlocker.mockImplementationOnce(() => ({
       updateBlocker: () => ({res: {statusCode: 200}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'resolved-1'
     storyInfoProvider.refresh = jest.fn()
     await resolveBlocker(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('resolvedBlocker', context)
@@ -35,7 +34,6 @@ describe('#resolveBlocker', () => {
     PtBlocker.mockImplementationOnce(() => ({
       updateBlocker: () => ({res: {statusCode: 201}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'complete-1'
     storyInfoProvider.refresh = jest.fn()
     await resolveBlocker(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('failedResolveBlocker')

--- a/lib/commands/resolveBlocker.spec.js
+++ b/lib/commands/resolveBlocker.spec.js
@@ -9,11 +9,13 @@ const PtBlocker = require('../../model/blockers')
 
 const context = Context.build()
 const storyInfoProvider = new StoryInfoDataProvider(context)
-const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider)
+const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
 
 describe('#resolveBlocker', () => {
   it('should fail if taskTreeItem lacks an itemid', () => {
-    resolveBlocker(taskTreeItem, context)
+    const taskTree = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
+    delete taskTree.itemId
+    resolveBlocker(taskTree, context)
     expect(rebounds).toBeCalledWith('failedResolveBlocker')
   })
 

--- a/lib/commands/undeliverTask.spec.js
+++ b/lib/commands/undeliverTask.spec.js
@@ -9,13 +9,15 @@ const PtTask = require('../../model/tasks')
 
 const context = Context.build()
 const storyInfoProvider = new StoryInfoDataProvider(context)
-const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider)
+const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
 
 describe('#undeliverTask', () => {
   afterEach(() => jest.clearAllMocks())
 
   it('should fail if taskTreeItem lacks an itemid', () => {
-    undeliverTask(taskTreeItem, context)
+    const taskTree = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
+    delete taskTree.itemId
+    undeliverTask(taskTree, context)
     expect(rebounds).toBeCalledWith('failedundeliveredTask')
   })
 

--- a/lib/commands/undeliverTask.spec.js
+++ b/lib/commands/undeliverTask.spec.js
@@ -25,7 +25,6 @@ describe('#undeliverTask', () => {
     PtTask.mockImplementationOnce(() => ({
       updateTask: () => ({res: {statusCode: 200}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'complete-1'
     storyInfoProvider.refresh = jest.fn()
     await undeliverTask(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('undeliveredTask', context)
@@ -36,7 +35,6 @@ describe('#undeliverTask', () => {
     PtTask.mockImplementationOnce(() => ({
       updateTask: () => ({res: {statusCode: 201}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'complete-1'
     storyInfoProvider.refresh = jest.fn()
     await undeliverTask(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('failedundeliveredTask')

--- a/lib/commands/unresolveBlocker.spec.js
+++ b/lib/commands/unresolveBlocker.spec.js
@@ -23,7 +23,6 @@ describe('#unresolveBlocker', () => {
     PtBlocker.mockImplementationOnce(() => ({
       updateBlocker: () => ({res: {statusCode: 200}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'resolved-1'
     storyInfoProvider.refresh = jest.fn()
     await unresolveBlocker(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('unresolvedBlocker', context)
@@ -35,7 +34,6 @@ describe('#unresolveBlocker', () => {
     PtBlocker.mockImplementationOnce(() => ({
       updateBlocker: () => ({res: {statusCode: 201}})
     }))
-    taskTreeItem.taskOrBlockerContext = 'complete-1'
     storyInfoProvider.refresh = jest.fn()
     await unresolveBlocker(taskTreeItem, context)
     expect(rebounds).toBeCalledWith('failedUnresolveBlocker')

--- a/lib/commands/unresolveBlocker.spec.js
+++ b/lib/commands/unresolveBlocker.spec.js
@@ -9,11 +9,13 @@ const PtBlocker = require('../../model/blockers')
 
 const context = Context.build()
 const storyInfoProvider = new StoryInfoDataProvider(context)
-const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider)
+const taskTreeItem = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
 
 describe('#unresolveBlocker', () => {
   it('should fail if taskTreeItem lacks an itemid', () => {
-    unresolveBlocker(taskTreeItem, context)
+    const taskTree = new TaskTreeItem('My task', storyInfoProvider, 'item-1')
+    delete taskTree.itemId
+    unresolveBlocker(taskTree, context)
     expect(rebounds).toBeCalledWith('failedUnresolveBlocker')
   })
 

--- a/lib/validation/rebounds.js
+++ b/lib/validation/rebounds.js
@@ -93,5 +93,10 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
       break
     case 'failedUnresolveBlocker':
       window.showErrorMessage(msg || 'Failed to unresolve blocker')
+    case 'failedAddBlocker':
+      window.showErrorMessage(msg || 'Could not add blocker')
+    case 'addBlocker':
+      await refreshState(ctx)
+      window.showInformationMessage(msg || 'Added blocker successfully')
   }
 }

--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -37,6 +37,7 @@ class StoryInfoDataProvider {
     }
 
     const Blockers = new TreeItem('Blockers', TreeItemCollapsibleState.Collapsed)
+    Blockers.contextValue = 'blockerTitle'
     Blockers.iconPath = {
       light: this._context.asAbsolutePath('images/octicons/alert.svg'),
       dark: this._context.asAbsolutePath('images/octicons/alert-light.svg')

--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -64,7 +64,7 @@ class StoryInfoDataProvider {
   }
 
   async _getExpandableChild(element) {
-    if(element.label == 'Tasks') {
+    if(element.label === 'Tasks') {
       const taskResource = new PtTask(this._context, this._storyId)
       let storyTasks
       try {
@@ -75,7 +75,7 @@ class StoryInfoDataProvider {
       return this._getTreeItemsFromDescriptions(storyTasks, 'tasks')
     }
 
-    if(element.label == 'Blockers') {
+    if(element.label === 'Blockers') {
       const blockersResource = new PtBlocker(this._context, this._storyId)
       let storyBlockers
       try {
@@ -90,9 +90,7 @@ class StoryInfoDataProvider {
 
   _getTreeItemsFromDescriptions(items, label) {
     const treeItems = items.map(item => {
-      const treeItem =  new TaskAndBlockerTreeItem(item.description, this)
-      treeItem.taskOrBlockerContext = this._generateContextValue(item)
-      return treeItem
+      return new TaskAndBlockerTreeItem(item.description, this, this._generateContextValue(item))
     })
     return treeItems.length ? treeItems : [new TreeItem(`No ${label} yet`)]
   }

--- a/lib/views/storyInfo/taskAndBlockerTreeItem.js
+++ b/lib/views/storyInfo/taskAndBlockerTreeItem.js
@@ -1,15 +1,10 @@
 const {TreeItem} = require('vscode')
 
 class TaskAndBlockerTreeItem extends TreeItem {
-  constructor(label, StoryDataProvider) {
+  constructor(label, StoryDataProvider, contextValues) {
     super(label)
     this.dataProvider = StoryDataProvider
-  }
-
-  set taskOrBlockerContext(value) {
-    const [contextValue, itemId] = value.split('-')
-    this.contextValue = contextValue
-    this.itemId =itemId
+    [this.contextValue, this.itemId] = contextValues.split('-')
   }
 
   get taskOrBlockerContext() {

--- a/lib/views/storyInfo/taskAndBlockerTreeItem.js
+++ b/lib/views/storyInfo/taskAndBlockerTreeItem.js
@@ -4,7 +4,9 @@ class TaskAndBlockerTreeItem extends TreeItem {
   constructor(label, StoryDataProvider, contextValues) {
     super(label)
     this.dataProvider = StoryDataProvider
-    [this.contextValue, this.itemId] = contextValues.split('-')
+    const splitValues = contextValues.split('-')
+    this.contextValue = splitValues[0]
+    this.itemId = splitValues[1]
   }
 
   get taskOrBlockerContext() {

--- a/lib/views/storyInfo/taskAndBlockerTreeItem.spec.js
+++ b/lib/views/storyInfo/taskAndBlockerTreeItem.spec.js
@@ -4,16 +4,15 @@ const Context = require('../../../test/factories/vscode/context')
 
 const context = Context.build()
 const StoryInfoProvider = new StoryInfoDataProvider(context)
-const TaskTreeItem = new TaskAndBlockerTreeItem('My task', StoryInfoProvider)
+const TaskTreeItem = new TaskAndBlockerTreeItem('My task', StoryInfoProvider, 'item-1')
 
 describe('#taskAndBlockerTreeItem', () => {
   it('should set itemid and context value when taskOrBlockerContext is set', () => {
-    TaskTreeItem.taskOrBlockerContext = 'complete-1'
-    expect(TaskTreeItem.contextValue).toBe('complete')
+    expect(TaskTreeItem.contextValue).toBe('item')
     expect(TaskTreeItem.itemId).toBe('1')
   })
 
   it('should get taskOrBlockerContext as was set', () => {
-    expect(TaskTreeItem.taskOrBlockerContext).toBe('complete-1')
+    expect(TaskTreeItem.taskOrBlockerContext).toBe('item-1')
   })
 })

--- a/model/blockers/index.js
+++ b/model/blockers/index.js
@@ -10,6 +10,7 @@ class PtBlocker extends PtStory {
   get _blockerEndpoints() {
     return {
       ...this._endpoints,
+      createBlocker: this._baseBlockerPath,
       getBlockers: this._baseBlockerPath,
       updateBlocker: `${this._baseBlockerPath}/${this.blockerId}`
     }
@@ -21,6 +22,14 @@ class PtBlocker extends PtStory {
 
   updateBlocker(updateData) {
     return this._update('put', this._blockerEndpoints.updateBlocker, updateData)
+  }
+
+  createBlocker(description) {
+    return this._update('post', this._blockerEndpoints.createBlocker, {
+      description, 
+      story_id: this.storyId,
+      project_id: this._projectId
+    })
   }
 }
 

--- a/model/blockers/index.spec.js
+++ b/model/blockers/index.spec.js
@@ -1,0 +1,36 @@
+jest.mock('../index')
+const Model = require('../index')
+const Blocker = require('./index')
+const Context = require('../../test/factories/vscode/context')
+
+const context = Context.build()
+
+const PtBlocker = new Blocker(context, 1, 2)
+
+describe('#blockers', () => {
+  describe('getBlockers', () => {
+    test('should fetch using getBlockers endpoint', () => {
+      PtBlocker.getBlockers()
+      expect(Model.mock.instances[0]._fetch).toBeCalledWith('get', PtBlocker._blockerEndpoints.getBlockers)
+    })
+  })
+
+  describe('updateBlocker', () => {
+    test('should update using updateBlockers endpoint', () => {
+      PtBlocker.updateBlocker({resolved: true})
+      expect(Model.mock.instances[0]._update).toBeCalledWith('put', PtBlocker._blockerEndpoints.updateBlocker, {resolved: true})
+    })
+  })
+
+  describe('createBlocker', () => {
+    test('should update using createBlocker endpoint', () => {
+      const description = 'new blocker'
+      PtBlocker.createBlocker(description)
+      expect(Model.mock.instances[0]._update).toBeCalledWith('post', PtBlocker._blockerEndpoints.createBlocker, {
+        description,
+        story_id: 1,
+        project_id: PtBlocker._projectId
+      })
+    })
+  })
+})

--- a/model/index.js
+++ b/model/index.js
@@ -8,8 +8,8 @@ class Model {
   constructor(context) {
     this._context = context
     this._pivotalTrackerClient = clients.createJsonClient(common.globals.pivotalBaseUrl)
-    const projectId = context.workspaceState.get(common.globals.projectID)
-    this._baseApiPath = `${common.globals.pivotalApiPrefix}/projects/${projectId}`
+    this._projectId = context.workspaceState.get(common.globals.projectID)
+    this._baseApiPath = `${common.globals.pivotalApiPrefix}/projects/${this._projectId}`
     this._token = context.globalState.get(common.globals.APItoken)
   }
 

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -48,7 +48,7 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.storyState.refreshMemberCycleView, () => commandRepo.refreshMemberCycleView(cycleTimeProvider)),
     commands.registerCommand(commandRepo.commands.storyState.deliverTask, taskTreeeItem => commandRepo.deliverTask(taskTreeeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unDeliverTask, taskTreeItem => commandRepo.undeliverTask(taskTreeItem, context)),
-    commands.registerCommand(commandRepo.commands.storyState.addBlocker, () => commandRepo.addBlocker()),
+    commands.registerCommand(commandRepo.commands.storyState.addBlocker, blockerTreeItem => commandRepo.addBlocker(blockerTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.resolveBlocker, blockerTreeItem => commandRepo.resolveBlocker(blockerTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unResolveBlocker, blockerTreeItem => commandRepo.unresolveBlocker(blockerTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.showStoryDescription, description => commandRepo.viewStoryDescription(description))

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -48,6 +48,7 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.storyState.refreshMemberCycleView, () => commandRepo.refreshMemberCycleView(cycleTimeProvider)),
     commands.registerCommand(commandRepo.commands.storyState.deliverTask, taskTreeeItem => commandRepo.deliverTask(taskTreeeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unDeliverTask, taskTreeItem => commandRepo.undeliverTask(taskTreeItem, context)),
+    commands.registerCommand(commandRepo.commands.storyState.addBlocker, () => commandRepo.addBlocker()),
     commands.registerCommand(commandRepo.commands.storyState.resolveBlocker, blockerTreeItem => commandRepo.resolveBlocker(blockerTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unResolveBlocker, blockerTreeItem => commandRepo.unresolveBlocker(blockerTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.showStoryDescription, description => commandRepo.viewStoryDescription(description))

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
         "command": "pivotaly.addBlocker",
         "title": "Add Blocker",
         "icon": {
-          "light": "images/octicons/plus-light.svg",
-          "dark": "images/octicons/plus.svg"
+          "dark": "images/octicons/plus-light.svg",
+          "light": "images/octicons/plus.svg"
         }
       },
       {
@@ -231,6 +231,11 @@
         {
           "command": "pivotaly.unResolveBlocker",
           "when": "viewItem == resolvedBlocker",
+          "group": "inline"
+        },
+        {
+          "command": "pivotaly.addBlocker",
+          "when": "viewItem == blockerTitle",
           "group": "inline"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -92,6 +92,14 @@
         }
       },
       {
+        "command": "pivotaly.addBlocker",
+        "title": "Add Blocker",
+        "icon": {
+          "light": "images/octicons/plus-light.svg",
+          "dark": "images/octicons/plus.svg"
+        }
+      },
+      {
         "command": "pivotaly.resolveBlocker",
         "title": "Resolve Blocker",
         "icon": {

--- a/test/factories/vscode/context.js
+++ b/test/factories/vscode/context.js
@@ -15,7 +15,8 @@ module.exports = new Factory()
         }
         const workspaceState = { 
           "pivotaly.state": JSON.stringify(state),
-          "pivotaly.isARepo": chance.bool()
+          "pivotaly.isARepo": chance.bool(),
+          "pivotaly.projectID": chance.integer()
         }
         return workspaceState[key]
       },


### PR DESCRIPTION
#### What does this PR do?
Enables creating blockers from story view
#### How should this be manually tested?
Enable extension, open story information view. You should be able to create a blocker from blocker title
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
<img width="245" alt="Screen Shot 2019-06-13 at 14 29 50" src="https://user-images.githubusercontent.com/19430730/59429130-c266f580-8de7-11e9-9673-633e1afc06a4.png">

#### Questions:
