### PR TITLE
Add tasks from story info 165934365

### DIFF
--- a/lib/commands/addTask.js
+++ b/lib/commands/addTask.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+
+}

--- a/lib/commands/addTask.js
+++ b/lib/commands/addTask.js
@@ -1,3 +1,25 @@
-module.exports = () => {
+const {window} = require('vscode')
+const Task = require('../../model/tasks')
+const rebounds = require('../validation/rebounds')
+const {getState} = require('../helpers/state')
 
+module.exports = async (taskTreeItem, context) => {
+  const description = await window.showInputBox({
+    prompt: 'Enter task description'
+  })
+  if(!description) return
+  const storyId = getState(context).story
+  const TaskResource = new Task(context, storyId, null)
+  let creation
+  try{
+    creation = await TaskResource.createTask(description)
+  } catch (error) {
+    return rebounds('failedAddTask')
+  }
+  if(creation.res.statusCode === 200) {
+    await rebounds('addTask', context)
+    taskTreeItem.dataProvider.refresh()
+    return
+  }
+  return rebounds('failedAddTask')
 }

--- a/lib/commands/addTask.spec.js
+++ b/lib/commands/addTask.spec.js
@@ -1,0 +1,44 @@
+jest.mock('../validation/rebounds')
+jest.mock('../../model/tasks')
+jest.mock('../helpers/state')
+const vscode = require('vscode')
+const addTask = require('./addTask')
+const rebounds = require('../validation/rebounds')
+const Task = require('../../model/tasks')
+const {getState} = require('../helpers/state')
+
+let taskTreeItem
+describe('#addBlocker', () => {
+  beforeEach(() => {
+    rebounds.mockImplementation(jest.fn())
+    taskTreeItem = {
+      dataProvider: {
+        refresh: jest.fn()
+      }
+    }
+    getState.mockReturnValue({story: 1})
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  test('should return undefined if no descriptions is provided', async () => {
+    vscode.window.showInputBox = jest.fn().mockResolvedValue(undefined)
+    const added = await addTask({}, {})
+    expect(added).toBe(undefined)
+  })
+
+  test('should refresh view if task is created successfully', async () => {
+    vscode.window.showInputBox = jest.fn().mockResolvedValue('new task description')
+
+    Task.mockImplementationOnce(() => ({
+      createTask: jest.fn().mockResolvedValue({
+        res: {
+          statusCode: 200
+        }
+      })
+    }))
+
+    await addTask(taskTreeItem, {})
+    expect(taskTreeItem.dataProvider.refresh).toBeCalledTimes(1)
+  })
+})

--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -8,6 +8,7 @@ exports.commands = {
     refreshMemberCycleView: 'pivotaly.refreshMemberCycleView',
     deliverTask: 'pivotaly.deliverTask',
     addBlocker: 'pivotaly.addBlocker',
+    addTask: 'pivotaly.addTask',
     unDeliverTask: 'pivotaly.unDeliverTask',
     resolveBlocker: 'pivotaly.resolveBlocker',
     unResolveBlocker: 'pivotaly.unResolveBlocker',

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,13 +1,14 @@
-const {commands} = require("./commands")
-const {startStory} = require("./startStory")
-const {stopStory} = require("./stopStory")
-const {deliverStory} = require("./deliverStory")
-const {finishStory} = require("./finishStory")
-const {linkStory} = require("./linkStory")
-const showAllCommands = require("./showAllCommands")
-const registerToken = require("./registerToken")
-const registerProjectID = require("./registerProjectID")
-const showStats = require("./showStats")
+const {commands} = require('./commands')
+const {startStory} = require('./startStory')
+const {stopStory} = require('./stopStory')
+const {deliverStory} = require('./deliverStory')
+const {finishStory} = require('./finishStory')
+const {linkStory} = require('./linkStory')
+const showAllCommands = require('./showAllCommands')
+const registerToken = require('./registerToken')
+const registerProjectID = require('./registerProjectID')
+const showStats = require('./showStats')
+const addTask = require('./addTask')
 const deliverTask = require('./deliverTask')
 const undeliverTask = require('./undeliverTask')
 const addBlocker = require('./addBlocker')
@@ -28,6 +29,7 @@ module.exports = {
   registerToken,
   registerProjectID,
   showStats,
+  addTask,
   deliverTask,
   undeliverTask,
   addBlocker,

--- a/lib/validation/rebounds.js
+++ b/lib/validation/rebounds.js
@@ -98,5 +98,10 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
     case 'addBlocker':
       await refreshState(ctx)
       window.showInformationMessage(msg || 'Added blocker successfully')
+    case 'failedAddTask':
+      window.showErrorMessage(msg || 'Could not add task')
+    case 'addTask':
+      await refreshState(ctx)
+      window.showInformationMessage(msg || 'Added task successfully')
   }
 }

--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -26,11 +26,13 @@ class StoryInfoDataProvider {
     const description = new TreeItem('View Description')
     description.command = {
       command: commandRepo.commands.storyState.showStoryDescription,
-      title: 'view description',
+      title: 'View description',
       arguments: [this._story.description]
     }
 
     const Tasks = new TreeItem('Tasks', TreeItemCollapsibleState.Collapsed)
+    Tasks.contextValue = 'taskTitle'
+    Tasks.dataProvider = this
     Tasks.iconPath = {
       light: this._context.asAbsolutePath('images/octicons/checklist.svg'),
       dark: this._context.asAbsolutePath('images/octicons/checklist-light.svg')
@@ -38,6 +40,7 @@ class StoryInfoDataProvider {
 
     const Blockers = new TreeItem('Blockers', TreeItemCollapsibleState.Collapsed)
     Blockers.contextValue = 'blockerTitle'
+    Blockers.dataProvider = this
     Blockers.iconPath = {
       light: this._context.asAbsolutePath('images/octicons/alert.svg'),
       dark: this._context.asAbsolutePath('images/octicons/alert-light.svg')

--- a/model/tasks/index.js
+++ b/model/tasks/index.js
@@ -11,6 +11,7 @@ class PtTask extends PtStory {
   get _taskEndpoints() {
     return {
       ...this._endpoints,
+      createTask: this._baseTasksPath,
       getAllTasks: this._baseTasksPath,
       updateTask: `${this._baseTasksPath}/${this.taskId}`
     }
@@ -22,6 +23,14 @@ class PtTask extends PtStory {
 
   updateTask(updateData) {
     return this._update('put', this._taskEndpoints.updateTask, updateData)
+  }
+
+  createTask(description) {
+    return this._update('post', this._taskEndpoints.createTask, {
+      description,
+      story_id: this.storyId,
+      project_id: this._projectId
+    })
   }
 }
 

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -46,6 +46,7 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.statistics.cycleTime, (context, iteration) =>  commandRepo.showStats(context, iteration)),
     commands.registerCommand(commandRepo.commands.storyState.refreshStateView, () => commandRepo.refreshStateView(context, storyInfoProvider)),
     commands.registerCommand(commandRepo.commands.storyState.refreshMemberCycleView, () => commandRepo.refreshMemberCycleView(cycleTimeProvider)),
+    commands.registerCommand(commandRepo.commands.storyState.addTask, taskTreeItem => commandRepo.addTask(taskTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.deliverTask, taskTreeeItem => commandRepo.deliverTask(taskTreeeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.unDeliverTask, taskTreeItem => commandRepo.undeliverTask(taskTreeItem, context)),
     commands.registerCommand(commandRepo.commands.storyState.addBlocker, blockerTreeItem => commandRepo.addBlocker(blockerTreeItem, context)),

--- a/package.json
+++ b/package.json
@@ -76,6 +76,14 @@
         }
       },
       {
+        "command": "pivotaly.addTask",
+        "title": "Add Task",
+        "icon": {
+          "dark": "images/octicons/plus-light.svg",
+          "light": "images/octicons/plus.svg"
+        }
+      },
+      {
         "command": "pivotaly.deliverTask",
         "title": "Deliver Task",
         "icon": {

--- a/package.json
+++ b/package.json
@@ -245,6 +245,11 @@
           "command": "pivotaly.addBlocker",
           "when": "viewItem == blockerTitle",
           "group": "inline"
+        },
+        {
+          "command": "pivotaly.addTask",
+          "when": "viewItem == taskTitle",
+          "group": "inline"
         }
       ]
     }


### PR DESCRIPTION
#### What does this PR do?
Adds functionality to add a task from story information view
#### How should this be manually tested?
Enable extension, open story information view. You should be able to create a task from task title
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
<img width="247" alt="Screen Shot 2019-06-13 at 16 40 21" src="https://user-images.githubusercontent.com/19430730/59437395-327e7700-8dfa-11e9-9f30-3232661344ac.png">

#### Questions:
n/a