### PR TITLE
Get story id using reg ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Pivotaly contributes the following settings:
 
 * `pivotaly.protectedBranches`: Array of git branches that are ideally not feature branches e.g. `master`. Pivotaly will not attempt to link a story to git branches added.
 
-* `pivotaly.branchDelimiter`: Delimiter to use to retrieve story ID. e.g. set to `'-'` to get id `345` from `ft-edit-read-me-345` or `'_'` to get `345` from `ft-edit-read-me_345`
+* `pivotaly.branchDelimiter`: Delimiter string or RegExp to use to retrieve story ID. e.g. set to `'-'` to get id `345` from `ft-edit-read-me-345` or `'_'` to get `345` from `ft-edit-read-me_345`  or `[\/-]` to get `678` from `feature/678-read-me`
 
 ## Known Issues
 

--- a/lib/commands/linkStory.js
+++ b/lib/commands/linkStory.js
@@ -12,7 +12,12 @@ const validateStoryID = (context, isARepo) =>
 
 const linkStory = async (context, storyInfoProvider) => {
   const isARepo = context.workspaceState.get(common.globals.isARepo)
-  const shouldLink = await validateStoryID(context, isARepo)
+  let shouldLink
+  try {
+    shouldLink = await validateStoryID(context, isARepo)
+  } catch(err) {
+    shouldLink = false
+  }
   if(!shouldLink) return rebounds('failedLinkedStory', context)
 
   const iterationsResource = new PtIterations(context)

--- a/lib/helpers/stories.js
+++ b/lib/helpers/stories.js
@@ -2,19 +2,16 @@ const {workspace} = require("vscode")
 const {isStoryIDValid} = require("../validation/validators/isStoryIDValid")
 
 const getStoryID = async (context, branch) => {
-  const delimiter = workspace.getConfiguration().get('pivotaly.branchDelimiter')
+  const delimiter = new RegExp(workspace.getConfiguration().get('pivotaly.branchDelimiter'))
   const splitBranch = branch.split(delimiter)
-  const postStoryID = splitBranch.pop()
-  const [preStoryID] = splitBranch
+  const allStories = splitBranch.map(element => isStoryIDValid(context, element))
+  const validStoryIds = await Promise.all(allStories)
+  const storyIndex = validStoryIds.findIndex(el => el)
 
-  const isPostStoryValid = await isStoryIDValid(context, postStoryID)
-  if(isPostStoryValid)
-    return postStoryID
-  
-  const isPreStoryValid = await isStoryIDValid(context, preStoryID)
-  if(isPreStoryValid)
-    return preStoryID
-  return undefined
+  if(storyIndex === -1) {
+    return undefined
+  }
+  return splitBranch[storyIndex]
 }
 
 module.exports = {

--- a/lib/helpers/stories.spec.js
+++ b/lib/helpers/stories.spec.js
@@ -1,4 +1,5 @@
 jest.mock("../validation/validators/isStoryIDValid")
+const vscode = require('vscode')
 const {isStoryIDValid} = require("../validation/validators/isStoryIDValid")
 const {getStoryID} = require('./stories')
 const Context = require('../../test/factories/vscode/context')
@@ -10,18 +11,26 @@ describe('#pivotaly getStoryId', () => {
     jest.clearAllMocks()
   })
   it('get post story id successfully', async () => {
-    isStoryIDValid.mockReturnValueOnce(true)
+    isStoryIDValid.mockImplementation((ctx,id) => id === '54324')
     const result = await getStoryID(context, 'post-story-id-54324')
     expect(result).toEqual('54324')
   })
   it('get pre story id successfully', async () => {
-    isStoryIDValid.mockReturnValueOnce(false).mockReturnValueOnce(true)
+    isStoryIDValid.mockImplementation((ctx,id) => id === '27343')
     const result = await getStoryID(context, '27343-pre-story-id')
     expect(result).toEqual('27343')
   })
   it('Fail to get post or pre story id', async () => {
-    isStoryIDValid.mockReturnValueOnce(false).mockReturnValueOnce(false)
+    isStoryIDValid.mockImplementation((ctx,id) => id === '54324')
     const result = await getStoryID(context, 'story')
     expect(typeof result).toEqual('undefined')
+  })
+  it('get story id with regexp delimiter successfully', async () => {
+    vscode.workspace.getConfiguration = jest.fn(() => ({
+      get: () => '[\/-]'
+    }))
+    isStoryIDValid.mockImplementation((ctx, id) => id === '88623')
+    const result = await getStoryID(context, 'feature/88623-pre-story-id')
+    expect(result).toEqual('88623')
   })
 })


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Fixes issue #83 . Adds option to use a Regular Expression as a branch delimiter.
#### How should this be manually tested?
Change delimiter setting to a regular expression and check out to a new branch whose story id can be obtained using the regular expression. The story should be detected.
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a