### PR TITLE
Remove hanging 'stories attempted' if none was attempted

### DIFF
--- a/lib/stats/templates/prepareUserCard.js
+++ b/lib/stats/templates/prepareUserCard.js
@@ -51,7 +51,7 @@ module.exports = member => {
   <h4>${ member.iteration_stories.length } ${getPlural('story', member.iteration_stories.length)} attempted: ${storyCount.feature} ${getPlural('feature', storyCount.feature)}, ${storyCount.chore} ${getPlural('chore', storyCount.chore)}, ${storyCount.bug} ${getPlural('bug', storyCount.bug)}</h4>
   <h4>Total Points Assigned: ${totalAssignedPoints}</h5>
   <h4>Total Points Completed: ${totalFeaturePoints}</h5>
-  <h4>Stories Attempted:</h4>
+  <h4>${storyList.length ? 'Stories Attempted:' : ''}</h4>
   <ul>${storyList}</ul>
 </div>
 `)


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Remove hanging `stories attempted:` if none was attempted in member cycle time cards

#### How should this be manually tested?
Show stats for an iteration where no stories were attempted. The heading `stories attempted:` should not appear.

#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a
