### PR TITLE
Fix  _context.asAbsolutePath is not a function error

### DIFF
--- a/test/factories/vscode/context.js
+++ b/test/factories/vscode/context.js
@@ -24,3 +24,4 @@ module.exports = new Factory()
     }
   ]))
   .attr('subscriptions', [])
+  .attr('asAbsolutePath', () => path => path)


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Fixes error `this._context.asAbsolutePath is not a function` during testing
#### How should this be manually tested?
`jest --coverage --coverageReporters=text-lcov | coveralls.js` should not generate an error
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a