### PR TITLE
Add option to reinstate workspace 166132210

### DIFF
--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -23,6 +23,7 @@ exports.commands = {
   internal: {
     showCommandsQuickPick: "pivotaly.showCommandQuickPick",
     registerToken: "pivotaly.registerToken",
-    registerProjectID: "pivotaly.registerProjectID"
+    registerProjectID: "pivotaly.registerProjectID",
+    reinstateWorkspace: "pivotaly.reinstateWorkspace"
   }
 }

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -17,6 +17,7 @@ const unresolveBlocker = require('./unresolveBlocker')
 const refreshStateView = require('./refreshStateView')
 const viewStoryDescription = require('./viewStoryDescription')
 const refreshMemberCycleView = require('./refreshMemberCycleView')
+const reinstateWorkspace = require('./reinstateWorkspace')
 
 module.exports = {
   commands,
@@ -37,5 +38,6 @@ module.exports = {
   unresolveBlocker,
   refreshStateView,
   viewStoryDescription,
-  refreshMemberCycleView
+  refreshMemberCycleView,
+  reinstateWorkspace
 }

--- a/lib/commands/reinstateWorkspace.js
+++ b/lib/commands/reinstateWorkspace.js
@@ -1,0 +1,7 @@
+const {common} = require('./common')
+const {commands} = require('vscode')
+
+module.exports = context => {
+  context.workspaceState.update(common.globals.notPTProject, false)
+  commands.executeCommand('workbench.action.reloadWindow')
+}

--- a/lib/commands/reinstateWorkspace.spec.js
+++ b/lib/commands/reinstateWorkspace.spec.js
@@ -1,0 +1,24 @@
+const vscode = require('vscode')
+const reinstateWorkspace = require('./reinstateWorkspace')
+const {common} = require('./common')
+const Context = require('../../test/factories/vscode/context')
+
+const context = Context.build()
+
+describe('#reinstateWorkspace', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  test('it should set workspace as a pt project', () => {
+    context.workspaceState.update = jest.fn()
+    reinstateWorkspace(context)
+    expect(context.workspaceState.update).toBeCalledTimes(1)
+    expect(context.workspaceState.update).toBeCalledWith(common.globals.notPTProject, false)
+  })
+
+  test('it should reload window', () => {
+    const reloadCommand = 'workbench.action.reloadWindow'
+    reinstateWorkspace(context)
+    expect(vscode.commands.executeCommand).toBeCalledTimes(1)
+    expect(vscode.commands.executeCommand).toBeCalledWith(reloadCommand)
+  })
+})

--- a/lib/views/controlPanel/cpDataProvider.js
+++ b/lib/views/controlPanel/cpDataProvider.js
@@ -5,31 +5,42 @@ class ControlPanelDataProvider {
   /**
    * @param {object} context
    * @param {import("vscode").TreeDataProvider} storyInfoDataProvider story info view
-   * @param {import("vscode").TreeDataProvider} cycleTimeDataProvider member cycle view 
+   * @param {import("vscode").TreeDataProvider} cycleTimeDataProvider member cycle view
+   * @param {boolean} isPtProject flag to show if the workspace has been marked as a Pivotal Tracker Project or not
    */
-  constructor(context, storyInfoDataProvider, cycleTimeDataProvider) {
+  constructor(context, storyInfoDataProvider, cycleTimeDataProvider, isPtProject = true) {
     this._context = context
     this._storyInfoDataProvider = storyInfoDataProvider
     this._cycleTimeDataProvider = cycleTimeDataProvider
+    this.isPtProject = isPtProject
   }
 
   /**
    * @param {object} _element
    */
   async getChildren(_element) {
-    const editToken = new TreeItem('Edit token', TreeItemCollapsibleState.None)
-    editToken.command = {
-      title: 'Edit or add token',
-      command: commands.internal.registerToken,
-      arguments: [this._context, this._storyInfoDataProvider, this._cycleTimeDataProvider]
+    if(this.isPtProject) {
+      const editToken = new TreeItem('Edit token', TreeItemCollapsibleState.None)
+      editToken.command = {
+        title: 'Edit or add token',
+        command: commands.internal.registerToken,
+        arguments: [this._context, this._storyInfoDataProvider, this._cycleTimeDataProvider]
+      }
+      const editProject = new TreeItem('Edit project', TreeItemCollapsibleState.None)
+      editProject.command = {
+        title: 'Edit or add project',
+        command: commands.internal.registerProjectID,
+        arguments: [this._context, this._storyInfoDataProvider, this._cycleTimeDataProvider]
+      }
+      return [editToken, editProject]
     }
-    const editProject = new TreeItem('Edit project', TreeItemCollapsibleState.None)
-    editProject.command = {
-      title: 'Edit or add project',
-      command: commands.internal.registerProjectID,
-      arguments: [this._context, this._storyInfoDataProvider, this._cycleTimeDataProvider]
+    const reinstateWorkspace = new TreeItem('Reinstate Workspace as a Pivotal Tracker Project', TreeItemCollapsibleState.None)
+    reinstateWorkspace.command = {
+      title: 'Reinstate Workspace',
+      command: commands.internal.reinstateWorkspace,
+      arguments: [this._context]
     }
-    return [editToken, editProject]
+    return [reinstateWorkspace]
   }
 
   /**

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -21,6 +21,7 @@ const setUpNotPtProjectEnvironment = async context => {
     commands.registerCommand(commandRepo.commands.internal.reinstateWorkspace, () => commandRepo.reinstateWorkspace(context))
   )
 }
+
 const activate = async context => {
   if(workspace.workspaceFolders === undefined) return
 

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -14,6 +14,13 @@ const {listenForCheckOut} = require('../lib/helpers/git')
 const GitEvents = require('../lib/events/gitEvents')
 
 
+const setUpNotPtProjectEnvironment = async context => {
+  const cpProvider = new ControlPanelDataProvider(context, null, null, false)
+  context.subscriptions.push(
+    window.registerTreeDataProvider(views.controlPanel, cpProvider),
+    commands.registerCommand(commandRepo.commands.internal.reinstateWorkspace, () => commandRepo.reinstateWorkspace(context))
+  )
+}
 const activate = async context => {
   if(workspace.workspaceFolders === undefined) return
 
@@ -22,7 +29,12 @@ const activate = async context => {
   const isARepo = rootPath ? await isRepo(rootPath) : false
   context.workspaceState.update(common.globals.isARepo, isARepo)
 
-  if(context.workspaceState.get(common.globals.notPTProject) === true) return;
+  /*
+  For testing
+  Set notPTProject as true
+  */
+  context.workspaceState.update(common.globals.notPTProject, true)
+  if(context.workspaceState.get(common.globals.notPTProject) === true) return setUpNotPtProjectEnvironment(context);
 
   const statusBarItem = createPTStatusBarItem()
 

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -29,11 +29,6 @@ const activate = async context => {
   const isARepo = rootPath ? await isRepo(rootPath) : false
   context.workspaceState.update(common.globals.isARepo, isARepo)
 
-  /*
-  For testing
-  Set notPTProject as true
-  */
-  context.workspaceState.update(common.globals.notPTProject, true)
   if(context.workspaceState.get(common.globals.notPTProject) === true) return setUpNotPtProjectEnvironment(context);
 
   const statusBarItem = createPTStatusBarItem()


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Adds option to reinstate workspace as a Pivotal Tracker Project after marking it as not a project

#### How should this be manually tested?
- Mark a new workspace as not a pt project.
- An option to reinstate the workspace should appear in the control panel viewlet

#### Any background context you want to provide?

#### Screenshots (if appropriate)
![Screen Shot 2020-01-23 at 17 43 13](https://user-images.githubusercontent.com/19430730/72994294-e8d22200-3e07-11ea-8b33-4788b850aaba.png)

#### Questions:
