### PR TITLE
Add default description if no description exists

### DIFF
--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -25,7 +25,7 @@ class StoryInfoDataProvider extends PivotalyDataProvider {
     description.command = {
       command: commandRepo.commands.storyState.showStoryDescription,
       title: 'View description',
-      arguments: [this._story.description]
+      arguments: [this._story.description || '*This story has no description*']
     }
 
     const Tasks = new PivotalyTreeItem('Tasks', this, 'taskTitle-#', TreeItemCollapsibleState.Expanded)


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Adds a default description *This story has no description* if a story has no description
#### How should this be manually tested?
Link a story that has no description and on the story information viewlet, click `View Description`
#### Any background context you want to provide?
Previously `View Description` displayed `undefined` if no description existed  
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a