### PR TITLE
Add estimate story to information viewlet

### DIFF
--- a/lib/commands/estimateStory.js
+++ b/lib/commands/estimateStory.js
@@ -22,7 +22,7 @@ module.exports = async (context, storyInfoDataProvider) => {
 
   try {
     await StoryResource.updateStory({estimate: parseFloat(estimate)})
-    rebound('estimateSucceeded', context)
+    await rebound('estimateSucceeded', context)
     storyInfoDataProvider.refresh()
   } catch (e) {
     rebound('estimateFailed', context)

--- a/lib/validation/rebounds.js
+++ b/lib/validation/rebounds.js
@@ -113,6 +113,7 @@ module.exports = async (elementValidated, ctx, msg = '', commandArgs = []) => {
       window.showErrorMessage(msg || 'Failed to copy text to clipboard')
       break
     case 'estimateSucceeded':
+      await setState(ctx)
       window.showInformationMessage(msg || 'Successfully changed story estimate')
       break
     case 'estimateFailed':

--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -28,13 +28,13 @@ class StoryInfoDataProvider extends PivotalyDataProvider {
       arguments: [this._story.description || '*This story has no description*']
     }
 
-    const Tasks = new PivotalyTreeItem('Tasks', this, 'taskTitle-#', TreeItemCollapsibleState.Expanded)
+    const Tasks = new PivotalyTreeItem('Tasks', this, 'taskTitle-#')
     Tasks.iconPath = {
       light: this._context.asAbsolutePath('images/octicons/checklist.svg'),
       dark: this._context.asAbsolutePath('images/octicons/checklist-light.svg')
     }
 
-    const Blockers = new PivotalyTreeItem('Blockers', this, 'blockerTitle-#', TreeItemCollapsibleState.Expanded)
+    const Blockers = new PivotalyTreeItem('Blockers', this, 'blockerTitle-#')
     Blockers.iconPath = {
       light: this._context.asAbsolutePath('images/octicons/alert.svg'),
       dark: this._context.asAbsolutePath('images/octicons/alert-light.svg')

--- a/lib/views/storyInfo/storyInfoDataProvider.js
+++ b/lib/views/storyInfo/storyInfoDataProvider.js
@@ -39,6 +39,12 @@ class StoryInfoDataProvider extends PivotalyDataProvider {
       light: this._context.asAbsolutePath('images/octicons/alert.svg'),
       dark: this._context.asAbsolutePath('images/octicons/alert-light.svg')
     }
+
+    const Estimate = new PivotalyTreeItem(`Points: ${this._story.estimate || 'Unestimated'}`, this, 'estimate-#')
+    Estimate.command = {
+      command: commandRepo.commands.storyState.estimateStory,
+      title: 'Estimate Story'
+    }
     
     return [
       new TreeItem(`Project ID: ${this._story.project_id}`),
@@ -47,6 +53,7 @@ class StoryInfoDataProvider extends PivotalyDataProvider {
       new TreeItem(`Name: ${this._story.name}`),
       new TreeItem(`Type: ${this._story.story_type}`),
       new TreeItem(`State: ${this._story.current_state}`),
+      Estimate,
       Tasks,
       Blockers
     ]


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
- Adds points and estimate story command to the story information viewlet
- Fixes issue with story information viewlet not refreshing after running estimate story command
#### How should this be manually tested?
- Open story information viewlet
- The estimate of the story should be listed as `Points: x`.
- Upon clicking on points, you should be able to change points
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)
<img width="259" alt="Screen Shot 2020-03-02 at 22 36 15" src="https://user-images.githubusercontent.com/19430730/75710970-9e7d7400-5cd6-11ea-8cdf-db643d374e81.png">

#### Questions:
n/a