### PR TITLE
Refresh backlog after changing token or project ID

### DIFF
--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -47,6 +47,7 @@ module.exports = {
   },
   EventEmitter: class {},
   commands: {
-    executeCommand: jest.fn()
+    executeCommand: jest.fn(),
+    registerCommand: jest.fn()
   }
 }

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -40,7 +40,7 @@ module.exports = async context => {
   window.showInformationMessage('Validating project id')
 
   const prevProjectId = context.workspaceState.get(common.globals.projectID, projectId)
-  context.workspaceState.update(common.globals.projectID, projectId)
+  await context.workspaceState.update(common.globals.projectID, projectId)
 
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -45,8 +45,9 @@ module.exports = async context => {
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
     window.showInformationMessage('Project ID updated successfully')
-    await commands.executeCommand(commandStrings.commands.workState.linkStory)
+    commands.executeCommand(commandStrings.commands.workState.linkStory)
     commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
+    commands.executeCommand(commandStrings.commands.storyState.refreshBacklog)
   } catch (e) {
     if(!e && context.workspaceState.get(common.globals.projectID, projectId) === projectId) {
       context.workspaceState.update(common.globals.projectID, prevProjectId)

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -4,7 +4,7 @@ const PtProject = require('../../model/projects')
 const {generateQuickPickArray, extractIdFromQuickPick} = require('../adapters/generateQuickPickArray')
 const {validate} = require('../validation/validate')
 const commandStrings = require('./commands')
-const {setUpNotPtProjectEnvironment} = require('../helpers/workspace')
+const {setUpNotPtProjectEnvironment, executeCommands} = require('../helpers/workspace')
 
 const onFailedFetch = () => window.showErrorMessage('Could not fetch projects')
 
@@ -45,12 +45,11 @@ module.exports = async context => {
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
     window.showInformationMessage('Project ID updated successfully')
-    const executeTheseCommands = [
+    executeCommands(
       commandStrings.commands.workState.linkStory,
       commandStrings.commands.storyState.refreshMemberCycleView,
       commandStrings.commands.storyState.refreshBacklog
-    ]
-    executeTheseCommands.forEach(command => commands.executeCommand(command))
+    )
   } catch (e) {
     if(!e && context.workspaceState.get(common.globals.projectID, projectId) === projectId) {
       context.workspaceState.update(common.globals.projectID, prevProjectId)

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -8,7 +8,7 @@ const {setUpNotPtProjectEnvironment} = require('../helpers/workspace')
 
 const onFailedFetch = () => window.showErrorMessage('Could not fetch projects')
 
-module.exports = async (context, storyInfoDataProvider, cycleTimeDataProvider) => {
+module.exports = async context => {
   const prompt = 'Pick a project for this workspace'
 
   const projectResource = new PtProject(context)
@@ -43,7 +43,7 @@ module.exports = async (context, storyInfoDataProvider, cycleTimeDataProvider) =
   context.workspaceState.update(common.globals.projectID, projectId)
 
   try {
-    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider])
+    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
     window.showInformationMessage('Project ID updated successfully')
     await commands.executeCommand(commandStrings.commands.workState.linkStory)
     commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -3,11 +3,8 @@ const {common} = require('../commands/common')
 const PtProject = require('../../model/projects')
 const {generateQuickPickArray, extractIdFromQuickPick} = require('../adapters/generateQuickPickArray')
 const {validate} = require('../validation/validate')
-const rebound = require('../validation/rebounds')
 const commandStrings = require('./commands')
-
-const onFailure = msg =>
-  window.showWarningMessage(msg)
+const {setUpNotPtProjectEnvironment} = require('../helpers/workspace')
 
 const onFailedFetch = () => window.showErrorMessage('Could not fetch projects')
 
@@ -24,30 +21,35 @@ module.exports = async (context, storyInfoDataProvider, cycleTimeDataProvider) =
   const notAPtProjectId = '!This is not a Pivotal Tracker Project'
   allProjects.push({name: '', id: notAPtProjectId})
   const allProjectsQuickPick = generateQuickPickArray(allProjects)
-  const project = window.showQuickPick(allProjectsQuickPick, {canPickMany: false, ignoreFocusOut: true, placeHolder: prompt})
 
-  return project.then(projectNameAndId => {
-    if(!projectNameAndId){
-      return onFailure('Project not updated. Previous project set will be used.')
-    }
-    const projectId = extractIdFromQuickPick(projectNameAndId)
-    if(projectId === notAPtProjectId) {
-      context.workspaceState.update(common.globals.notPTProject, true)
-      window.showInformationMessage('Workspace marked as not a pivotal tracker project. Pivotaly commands will not be available.')
-      context.subscriptions.forEach(el => el.dispose())
-      return
-    }
+  const projectNameAndId = await window.showQuickPick(allProjectsQuickPick, {
+    canPickMany: false,
+    ignoreFocusOut: true,
+    placeHolder: prompt
+  })
 
-    window.showInformationMessage('Validating project id')
-    const prevProjectId = context.workspaceState.update(common.globals.projectID, projectId)
-    context.workspaceState.update(common.globals.projectID, projectId)
+  if(!projectNameAndId) return
 
-    validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider]).then(_didProjectValidationSucceed => {
-      window.showInformationMessage('Project ID updated successfully')
-      rebound('story', context, 'Pick story for project', [context, storyInfoDataProvider])
-      commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView, [cycleTimeDataProvider])
-    }, _failedProjectValidationValue =>
+  const projectId = extractIdFromQuickPick(projectNameAndId)
+
+  if(projectId === notAPtProjectId) {
+    setUpNotPtProjectEnvironment(context, true)
+    return
+  }
+
+  window.showInformationMessage('Validating project id')
+
+  const prevProjectId = context.workspaceState.get(common.globals.projectID, projectId)
+  context.workspaceState.update(common.globals.projectID, projectId)
+
+  try {
+    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider])
+    window.showInformationMessage('Project ID updated successfully')
+    await commands.executeCommand(commandStrings.commands.workState.linkStory)
+    commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
+  } catch (e) {
+    if(!e && context.workspaceState.get(common.globals.projectID, projectId) === projectId) {
       context.workspaceState.update(common.globals.projectID, prevProjectId)
-    )
-  }, _onRej => onFailure('Project ID could not be set'))
+    }
+  }
 }

--- a/lib/commands/registerProjectID.js
+++ b/lib/commands/registerProjectID.js
@@ -45,9 +45,12 @@ module.exports = async context => {
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
     window.showInformationMessage('Project ID updated successfully')
-    commands.executeCommand(commandStrings.commands.workState.linkStory)
-    commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
-    commands.executeCommand(commandStrings.commands.storyState.refreshBacklog)
+    const executeTheseCommands = [
+      commandStrings.commands.workState.linkStory,
+      commandStrings.commands.storyState.refreshMemberCycleView,
+      commandStrings.commands.storyState.refreshBacklog
+    ]
+    executeTheseCommands.forEach(command => commands.executeCommand(command))
   } catch (e) {
     if(!e && context.workspaceState.get(common.globals.projectID, projectId) === projectId) {
       context.workspaceState.update(common.globals.projectID, prevProjectId)

--- a/lib/commands/registerProjectID.spec.js
+++ b/lib/commands/registerProjectID.spec.js
@@ -7,7 +7,7 @@ const Context = require('../../test/factories/vscode/context')
 const {commands} = require('../commands/commands')
 const vscode = require('vscode')
 const {validate} = require('../validation/validate')
-const {setUpNotPtProjectEnvironment} = require('../helpers/workspace')
+const {setUpNotPtProjectEnvironment, executeCommands} = require('../helpers/workspace')
 
 const context = Context.build()
 
@@ -79,19 +79,13 @@ describe('#registerProjectID', () => {
       jest.clearAllMocks()
     })
 
-    test('should attempt to link a story after successfully registering project ID', async () => {
+    test('should attempt to link a story, refresh member cycle and refresh backlog after successfully registering project ID', async () => {
       await registerProjectID(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.workState.linkStory)
-    })
-  
-    test('should attempt to refresh member cycle view after successfully registering project ID', async () => {
-      await registerProjectID(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshMemberCycleView)
-    })
-  
-    test('should attempt to refresh backlog view after successfully registering project ID', async () => {
-      await registerProjectID(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshBacklog)
+      expect(executeCommands).toBeCalledWith(
+        commands.workState.linkStory,
+        commands.storyState.refreshMemberCycleView,
+        commands.storyState.refreshBacklog
+      )
     })
   })
 })

--- a/lib/commands/registerProjectID.spec.js
+++ b/lib/commands/registerProjectID.spec.js
@@ -1,11 +1,13 @@
 jest.mock('../../model/projects')
 jest.mock('../validation/validate')
+jest.mock('../helpers/workspace')
 const PtProjects = require('../../model/projects')
 const registerProjectID = require('./registerProjectID')
 const Context = require('../../test/factories/vscode/context')
-const {common} = require('../commands/common')
+const {commands} = require('../commands/commands')
 const vscode = require('vscode')
 const {validate} = require('../validation/validate')
+const {setUpNotPtProjectEnvironment} = require('../helpers/workspace')
 
 const context = Context.build()
 
@@ -22,8 +24,9 @@ describe('#registerProjectID', () => {
     PtProjects.mockImplementationOnce(() => ({
       getAllProjects: jest.fn().mockRejectedValue('invalid_authentication')
     }))
-    const registered = await registerProjectID(context, {}, {})
+    const registered = await registerProjectID(context)
     expect(registered).toBe(undefined)
+    expect(vscode.window.showErrorMessage).toBeCalledWith('Could not fetch projects')
   })
 
   test('it fails to register if no project is provided', async () => {
@@ -33,24 +36,20 @@ describe('#registerProjectID', () => {
         data: [{id: 1, name: 'sample'}]
       })
     }))
-    const registered = await registerProjectID(context, {}, {})
+    const registered = await registerProjectID(context)
     expect(registered).toBe(undefined)
   })
 
-  test('disposes subscriptions and marks workspace as not a project if user marks workspace as not a pt project', async () => {
+  test('marks workspace as not a project if user marks workspace as not a pt project', async () => {
     vscode.window.showQuickPick = jest.fn().mockResolvedValue('!This is not a Pivotal Tracker Project')
     PtProjects.mockImplementationOnce(() => ({
       getAllProjects: jest.fn().mockResolvedValue({
         data: [{id: 1, name: 'sample'}]
       })
     }))
-    const dispose = jest.fn().mockReturnValue(undefined)
-    context.workspaceState.update = jest.fn().mockResolvedValue(true)
-    context.subscriptions.push({dispose}, {dispose})
-    await registerProjectID(context, {}, {})
-    expect(dispose).toBeCalledTimes(context.subscriptions.length)
-    expect(context.workspaceState.update).toBeCalledTimes(1)
-    expect(context.workspaceState.update).toBeCalledWith(common.globals.notPTProject, true)
+    await registerProjectID(context)
+    expect(setUpNotPtProjectEnvironment).toBeCalledTimes(1)
+    expect(setUpNotPtProjectEnvironment.mock.calls[0][1]).toBe(true)
   })
 
   test('validates project id picked', async () => {
@@ -61,7 +60,38 @@ describe('#registerProjectID', () => {
     }))
     vscode.window.showQuickPick = jest.fn().mockResolvedValue('1 - sample')
     validate.mockImplementationOnce(() => new Promise((_resolve, reject) => reject(false)))
-    await registerProjectID(context, {}, {})
+    await registerProjectID(context)
     expect(validate).toBeCalledTimes(1)
+  })
+
+  describe('On success', () => {
+    beforeAll(() => {
+      PtProjects.mockImplementation(() => ({
+        getAllProjects: jest.fn().mockResolvedValue({
+          data: [{id: 1, name: 'sample'}]
+        })
+      }))
+      vscode.window.showQuickPick = jest.fn().mockResolvedValue('1 - sample')
+      validate.mockResolvedValue(true)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('should attempt to link a story after successfully registering project ID', async () => {
+      await registerProjectID(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.workState.linkStory)
+    })
+  
+    test('should attempt to refresh member cycle view after successfully registering project ID', async () => {
+      await registerProjectID(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshMemberCycleView)
+    })
+  
+    test('should attempt to refresh backlog view after successfully registering project ID', async () => {
+      await registerProjectID(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshBacklog)
+    })
   })
 })

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -34,8 +34,9 @@ const registerToken = async context => {
 
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
-    await commands.executeCommand(commandStrings.commands.workState.linkStory)
+    commands.executeCommand(commandStrings.commands.workState.linkStory)
     commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
+    commands.executeCommand(commandStrings.commands.storyState.refreshBacklog)
   } catch (e) {
     return
   }

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -33,9 +33,12 @@ const registerToken = async context => {
 
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
-    commands.executeCommand(commandStrings.commands.workState.linkStory)
-    commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
-    commands.executeCommand(commandStrings.commands.storyState.refreshBacklog)
+    const executeTheseCommands = [
+      commandStrings.commands.workState.linkStory,
+      commandStrings.commands.storyState.refreshMemberCycleView,
+      commandStrings.commands.storyState.refreshBacklog
+    ]
+    executeTheseCommands.forEach(command => commands.executeCommand(command))
   } catch (e) {
     return
   }

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -7,7 +7,6 @@ const onRej = msg => window.showWarningMessage(msg)
 
 const saveToken = (context, token) => context.globalState.update(common.globals.APItoken, token)
 
-// TODO: Remove unnnecessarry provider arguments
 const registerToken = async context => {
   const prompt = 'Please provide a valid Pivotal Tracker API token. You can get it from your Pivotal Tracker profile.'
 

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -2,12 +2,12 @@ const {commands, window} = require('vscode')
 const {common} = require('../commands/common')
 const {validate} = require('../validation/validate')
 const commandStrings = require('./commands')
-const commandRepo = require('./commands')
 
 const onRej = msg => window.showWarningMessage(msg)
 
 const saveToken = (context, token) => context.globalState.update(common.globals.APItoken, token)
 
+// TODO: Remove unnnecessarry provider arguments
 const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvider) => {
   const prompt = 'Please provide a valid Pivotal Tracker API token. You can get it from your Pivotal Tracker profile.'
 
@@ -25,7 +25,7 @@ const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvid
     await validate('token', context, true, 'Invalid token. Make sure you have copied the right value', [context, storyInfoDataProvider, cycleTimeDataProvider])
   } catch(e) {
     saveToken(context, previousToken)
-    const msg = e === false ?
+    const msg = !e ?
       'Invalid token. Make sure you have copied the right value':
       'Token not updated. Previous token set will be used.'
     onRej(msg)
@@ -34,7 +34,7 @@ const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvid
 
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider])
-    await commands.executeCommand(commandRepo.commands.workState.linkStory)
+    await commands.executeCommand(commandStrings.commands.workState.linkStory)
     commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
   } catch (e) {
     return

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -18,7 +18,7 @@ const registerToken = async context => {
   window.showInformationMessage('Validating token')
 
   const previousToken = context.globalState.get(common.globals.APItoken, null)
-  saveToken(context, token)
+  await saveToken(context, token)
 
 
   try {

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -1,34 +1,44 @@
 const {commands, window} = require('vscode')
 const {common} = require('../commands/common')
 const {validate} = require('../validation/validate')
-const rebound = require('../validation/rebounds')
 const commandStrings = require('./commands')
+const commandRepo = require('./commands')
 
 const onRej = msg => window.showWarningMessage(msg)
 
-const registerToken = (context, storyInfoDataProvider, cycleTimeDataProvider) => {
+const saveToken = (context, token) => context.globalState.update(common.globals.APItoken, token)
+
+const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvider) => {
   const prompt = 'Please provide a valid Pivotal Tracker API token. You can get it from your Pivotal Tracker profile.'
 
-  const tokenPromise = window.showInputBox({ignoreFocusOut: true, password: true, placeHolder: 'Enter pivotal tracker API token', prompt})
-  return tokenPromise.then(token => {
-    if(!token) return onRej('Token not updated. Previous token set will be used.')
+  const token =  await window.showInputBox({ignoreFocusOut: true, password: true, placeHolder: 'Enter pivotal tracker API token', prompt})
 
-    window.showInformationMessage('Validating token')
-    const previousToken = context.globalState.get(common.globals.APItoken, null)
-    context.globalState.update(common.globals.APItoken, token)
+  if(!token) return
 
-    validate('token', context, true, 'Invalid token. Make sure you have copied the right value', [context, storyInfoDataProvider, cycleTimeDataProvider]).then(() => {
-      window.showInformationMessage('Pivotal Tracker API token updated successfully')
-      validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider]).then(() => {
-        rebound('story', context, 'Pick story for project', [context, storyInfoDataProvider])
-        commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView, [cycleTimeDataProvider])
-      }, () => {})
-    }, () =>
-      context.globalState.update(common.globals.APItoken, previousToken)
-    )
-  },
-  () => onRej('Token not set. You will not be able to use all pivotaly features')
-  )
+  window.showInformationMessage('Validating token')
+
+  const previousToken = context.globalState.get(common.globals.APItoken, null)
+  saveToken(context, token)
+
+
+  try {
+    await validate('token', context, true, 'Invalid token. Make sure you have copied the right value', [context, storyInfoDataProvider, cycleTimeDataProvider])
+  } catch(e) {
+    saveToken(context, previousToken)
+    const msg = e === false ?
+      'Invalid token. Make sure you have copied the right value':
+      'Token not updated. Previous token set will be used.'
+    onRej(msg)
+    return
+  }
+
+  try {
+    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider])
+    await commands.executeCommand(commandRepo.commands.workState.linkStory)
+    commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
+  } catch (e) {
+    return
+  }
 }
 
 module.exports = registerToken

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -8,7 +8,7 @@ const onRej = msg => window.showWarningMessage(msg)
 const saveToken = (context, token) => context.globalState.update(common.globals.APItoken, token)
 
 // TODO: Remove unnnecessarry provider arguments
-const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvider) => {
+const registerToken = async context => {
   const prompt = 'Please provide a valid Pivotal Tracker API token. You can get it from your Pivotal Tracker profile.'
 
   const token =  await window.showInputBox({ignoreFocusOut: true, password: true, placeHolder: 'Enter pivotal tracker API token', prompt})
@@ -22,7 +22,7 @@ const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvid
 
 
   try {
-    await validate('token', context, true, 'Invalid token. Make sure you have copied the right value', [context, storyInfoDataProvider, cycleTimeDataProvider])
+    await validate('token', context, true, 'Invalid token. Make sure you have copied the right value')
   } catch(e) {
     saveToken(context, previousToken)
     const msg = !e ?
@@ -33,7 +33,7 @@ const registerToken = async (context, storyInfoDataProvider, cycleTimeDataProvid
   }
 
   try {
-    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.', [context, storyInfoDataProvider, cycleTimeDataProvider])
+    await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
     await commands.executeCommand(commandStrings.commands.workState.linkStory)
     commands.executeCommand(commandStrings.commands.storyState.refreshMemberCycleView)
   } catch (e) {

--- a/lib/commands/registerToken.js
+++ b/lib/commands/registerToken.js
@@ -2,6 +2,7 @@ const {commands, window} = require('vscode')
 const {common} = require('../commands/common')
 const {validate} = require('../validation/validate')
 const commandStrings = require('./commands')
+const {executeCommands} = require('../helpers/workspace')
 
 const onRej = msg => window.showWarningMessage(msg)
 
@@ -33,12 +34,11 @@ const registerToken = async context => {
 
   try {
     await validate('projectID', context, true, 'Invalid ProjectID. Please pick a valid project.')
-    const executeTheseCommands = [
+    executeCommands(
       commandStrings.commands.workState.linkStory,
       commandStrings.commands.storyState.refreshMemberCycleView,
       commandStrings.commands.storyState.refreshBacklog
-    ]
-    executeTheseCommands.forEach(command => commands.executeCommand(command))
+    )
   } catch (e) {
     return
   }

--- a/lib/commands/registerToken.spec.js
+++ b/lib/commands/registerToken.spec.js
@@ -3,6 +3,7 @@ const vscode = require('vscode')
 const registerToken = require('./registerToken')
 const Context = require('../../test/factories/vscode/context')
 const {validate} = require('../validation/validate')
+const {commands} = require('../commands/commands')
 
 const context = Context.build()
 
@@ -10,6 +11,11 @@ describe('#registerToken', () => {
   beforeAll(() => {
     vscode.window.showWarningMessage = jest.fn().mockResolvedValue(undefined)
     vscode.window.showInformationMessage = jest.fn().mockResolvedValue(undefined)
+
+    context.globalState = {
+      get: jest.fn().mockReturnValue('prevToken'),
+      update: jest.fn().mockResolvedValue(true)
+    }
   })
 
   afterEach(() => {
@@ -18,20 +24,47 @@ describe('#registerToken', () => {
 
   test('it should not register if no token is provided', async () => {
     vscode.window.showInputBox = jest.fn().mockResolvedValue('')
-    const registered = await registerToken(context, {}, {})
+    const registered = await registerToken(context)
     expect(registered).toBeUndefined()
   })
 
   test('it should validate token put', async () => {
-    validate.mockImplementationOnce(() => new Promise((_resolve, reject) => reject(false)))
+    validate.mockRejectedValueOnce(false)
     vscode.window.showInputBox = jest.fn().mockResolvedValue('token')
 
-    context.globalState = {
-      get: jest.fn().mockReturnValue('prevToken'),
-      update: jest.fn().mockReturnValue(true)
-    }
-    await registerToken(context, {}, {})
+    
+    await registerToken(context)
     expect(validate).toBeCalledTimes(1)
     expect(context.globalState.update).toBeCalledTimes(2)
+    expect(vscode.window.showWarningMessage).toBeCalledWith('Invalid token. Make sure you have copied the right value')
+  })
+
+  describe('On success', () => {
+    beforeAll(() => {
+      vscode.window.showInputBox.mockResolvedValue('token')
+      validate.mockResolvedValue(true)
+    })
+
+    test('should attempt to validate both token and projectID', async () => {
+      await registerToken(context)
+      expect(validate).toBeCalledTimes(2)
+      expect(validate.mock.calls[0][0]).toBe('token')
+      expect(validate.mock.calls[1][0]).toBe('projectID')
+    })
+
+    test('should attempt to link a story after successfully registering token', async () => {
+      await registerToken(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.workState.linkStory)
+    })
+  
+    test('should attempt to refresh member cycle view after successfully registering token', async () => {
+      await registerToken(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshMemberCycleView)
+    })
+  
+    test('should attempt to refresh backlog view after successfully registering token', async () => {
+      await registerToken(context)
+      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshBacklog)
+    })
   })
 })

--- a/lib/commands/registerToken.spec.js
+++ b/lib/commands/registerToken.spec.js
@@ -1,9 +1,11 @@
 jest.mock('../validation/validate')
+jest.mock('../helpers/workspace')
 const vscode = require('vscode')
 const registerToken = require('./registerToken')
 const Context = require('../../test/factories/vscode/context')
 const {validate} = require('../validation/validate')
 const {commands} = require('../commands/commands')
+const {executeCommands} = require('../helpers/workspace')
 
 const context = Context.build()
 
@@ -52,19 +54,13 @@ describe('#registerToken', () => {
       expect(validate.mock.calls[1][0]).toBe('projectID')
     })
 
-    test('should attempt to link a story after successfully registering token', async () => {
+    test('should attempt to link a story, refresh member cycle and refresh backlog after successfully registering token', async () => {
       await registerToken(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.workState.linkStory)
-    })
-  
-    test('should attempt to refresh member cycle view after successfully registering token', async () => {
-      await registerToken(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshMemberCycleView)
-    })
-  
-    test('should attempt to refresh backlog view after successfully registering token', async () => {
-      await registerToken(context)
-      expect(vscode.commands.executeCommand).toBeCalledWith(commands.storyState.refreshBacklog)
+      expect(executeCommands).toBeCalledWith(
+        commands.workState.linkStory,
+        commands.storyState.refreshMemberCycleView,
+        commands.storyState.refreshBacklog
+      )
     })
   })
 })

--- a/lib/helpers/workspace.js
+++ b/lib/helpers/workspace.js
@@ -1,0 +1,24 @@
+const {window, commands} = require('vscode')
+const commandStrings = require('../commands/commands')
+const reinstateWorkspace = require('../commands/reinstateWorkspace')
+const ControlPanelDataProvider = require('../views/controlPanel/cpDataProvider')
+const views = require('../views/views')
+const {common} = require('../commands/common')
+
+const setUpNotPtProjectEnvironment = async (context, wasAPtWorkspace) => {
+  if(wasAPtWorkspace) {
+    context.workspaceState.update(common.globals.notPTProject, true)
+    window.showInformationMessage('Workspace marked as not a pivotal tracker project. Pivotaly commands will not be available.')
+  }
+  if(context.subscriptions.length) context.subscriptions.forEach(el => el.dispose())
+
+  const cpProvider = new ControlPanelDataProvider(context, null, null, false)
+  context.subscriptions.push(
+    window.registerTreeDataProvider(views.controlPanel, cpProvider),
+    commands.registerCommand(commandStrings.commands.internal.reinstateWorkspace, () => reinstateWorkspace(context))
+  )
+}
+
+module.exports = {
+  setUpNotPtProjectEnvironment
+}

--- a/lib/helpers/workspace.js
+++ b/lib/helpers/workspace.js
@@ -7,7 +7,7 @@ const {common} = require('../commands/common')
 
 const setUpNotPtProjectEnvironment = async (context, wasAPtWorkspace) => {
   if(wasAPtWorkspace) {
-    context.workspaceState.update(common.globals.notPTProject, true)
+    await context.workspaceState.update(common.globals.notPTProject, true)
     window.showInformationMessage('Workspace marked as not a pivotal tracker project. Pivotaly commands will not be available.')
   }
   if(context.subscriptions.length) context.subscriptions.forEach(el => el.dispose())

--- a/lib/helpers/workspace.js
+++ b/lib/helpers/workspace.js
@@ -19,6 +19,11 @@ const setUpNotPtProjectEnvironment = async (context, wasAPtWorkspace) => {
   )
 }
 
+const executeCommands = (...commandSequence) =>
+  commandSequence.forEach(command =>
+    commands.executeCommand(command))
+
 module.exports = {
-  setUpNotPtProjectEnvironment
+  setUpNotPtProjectEnvironment,
+  executeCommands
 }

--- a/lib/helpers/workspace.spec.js
+++ b/lib/helpers/workspace.spec.js
@@ -1,39 +1,50 @@
 jest.mock('../views/controlPanel/cpDataProvider')
 const vscode = require('vscode')
 const Context = require('../../test/factories/vscode/context')
-const {setUpNotPtProjectEnvironment} = require('./workspace')
+const {setUpNotPtProjectEnvironment, executeCommands} = require('./workspace')
 const {common} = require('../commands/common')
 const ControlPanelDataProvider = require('../views/controlPanel/cpDataProvider')
 
 const context = Context.build()
 
 describe('#workspace', () => {
-  beforeAll(() => {
-    vscode.window.registerTreeDataProvider = jest.fn()
+  describe('setUpNotPtProjectEnvironment', () => {
+    beforeAll(() => {
+      vscode.window.registerTreeDataProvider = jest.fn()
+    })
+  
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+  
+    test('should mark workspace as not a Pt project if workspace was a pt project', async () => {
+      context.workspaceState.update = jest.fn()
+      await setUpNotPtProjectEnvironment(context, true)
+      expect(context.workspaceState.update).toBeCalledTimes(1)
+      expect(context.workspaceState.update).toBeCalledWith(common.globals.notPTProject, true)
+    })
+  
+    test('should dispose all disposables in subscriptions array', async () => {
+      const dispose = jest.fn()
+      context.subscriptions = [{dispose},{dispose}]
+      await setUpNotPtProjectEnvironment(context, false)
+      expect(dispose).toBeCalledTimes(2)
+    })
+  
+    test('should create a new control panel data provider for a non-pt workspace', async () => {
+      context.subscriptions = []
+      await setUpNotPtProjectEnvironment(context, false)
+      expect(ControlPanelDataProvider).toBeCalledTimes(1)
+      expect(ControlPanelDataProvider.mock.calls[0][3]).toBe(false)
+    })
   })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  test('should mark workspace as not a Pt project if workspace was a pt project', async () => {
-    context.workspaceState.update = jest.fn()
-    await setUpNotPtProjectEnvironment(context, true)
-    expect(context.workspaceState.update).toBeCalledTimes(1)
-    expect(context.workspaceState.update).toBeCalledWith(common.globals.notPTProject, true)
-  })
-
-  test('should dispose all disposables in subscriptions array', async () => {
-    const dispose = jest.fn()
-    context.subscriptions = [{dispose},{dispose}]
-    await setUpNotPtProjectEnvironment(context, false)
-    expect(dispose).toBeCalledTimes(2)
-  })
-
-  test('should create a new control panel data provider for a non-pt workspace', async () => {
-    context.subscriptions = []
-    await setUpNotPtProjectEnvironment(context, false)
-    expect(ControlPanelDataProvider).toBeCalledTimes(1)
-    expect(ControlPanelDataProvider.mock.calls[0][3]).toBe(false)
+  
+  describe('executeCommands', () => {
+    test('should call execute command on all commands provided', () => {
+      executeCommands('buy bread', 'cook dinner')
+      expect(vscode.commands.executeCommand).toBeCalledTimes(2)
+      expect(vscode.commands.executeCommand).toBeCalledWith('buy bread')
+      expect(vscode.commands.executeCommand).toBeCalledWith('cook dinner')
+    })
   })
 })

--- a/lib/helpers/workspace.spec.js
+++ b/lib/helpers/workspace.spec.js
@@ -1,0 +1,39 @@
+jest.mock('../views/controlPanel/cpDataProvider')
+const vscode = require('vscode')
+const Context = require('../../test/factories/vscode/context')
+const {setUpNotPtProjectEnvironment} = require('./workspace')
+const {common} = require('../commands/common')
+const ControlPanelDataProvider = require('../views/controlPanel/cpDataProvider')
+
+const context = Context.build()
+
+describe('#workspace', () => {
+  beforeAll(() => {
+    vscode.window.registerTreeDataProvider = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should mark workspace as not a Pt project if workspace was a pt project', async () => {
+    context.workspaceState.update = jest.fn()
+    await setUpNotPtProjectEnvironment(context, true)
+    expect(context.workspaceState.update).toBeCalledTimes(1)
+    expect(context.workspaceState.update).toBeCalledWith(common.globals.notPTProject, true)
+  })
+
+  test('should dispose all disposables in subscriptions array', async () => {
+    const dispose = jest.fn()
+    context.subscriptions = [{dispose},{dispose}]
+    await setUpNotPtProjectEnvironment(context, false)
+    expect(dispose).toBeCalledTimes(2)
+  })
+
+  test('should create a new control panel data provider for a non-pt workspace', async () => {
+    context.subscriptions = []
+    await setUpNotPtProjectEnvironment(context, false)
+    expect(ControlPanelDataProvider).toBeCalledTimes(1)
+    expect(ControlPanelDataProvider.mock.calls[0][3]).toBe(false)
+  })
+})

--- a/lib/views/controlPanel/cpDataProvider.js
+++ b/lib/views/controlPanel/cpDataProvider.js
@@ -1,5 +1,5 @@
 const {TreeItem, TreeItemCollapsibleState} = require('vscode')
-const {commands} = require('../../commands')
+const {commands} = require('../../commands/commands')
 const PivotalyDataProvider = require('../PivotalyDataProvider')
 
 class ControlPanelDataProvider extends PivotalyDataProvider {
@@ -9,7 +9,7 @@ class ControlPanelDataProvider extends PivotalyDataProvider {
    * @param {import("vscode").TreeDataProvider} cycleTimeDataProvider member cycle view
    * @param {boolean} isPtProject flag to show if the workspace has been marked as a Pivotal Tracker Project or not
    */
-  constructor(context, storyInfoDataProvider, cycleTimeDataProvider, isPtProject = true) {
+  constructor(context, storyInfoDataProvider, cycleTimeDataProvider, isPtProject) {
     super(context)
     this._storyInfoDataProvider = storyInfoDataProvider
     this._cycleTimeDataProvider = cycleTimeDataProvider

--- a/model/rebounds.js
+++ b/model/rebounds.js
@@ -22,7 +22,7 @@ module.exports = async (err, msg = '') => {
       commands.executeCommand(commandRepo.commands.internal.registerToken)
       break
     case 'invalid_parameter':
-      const hasEstimateError =
+      const hasEstimateError = err.body.validation_errors &&
         err.body.validation_errors.some(valError => valError.field === 'estimate')
       if(hasEstimateError) {
         window.showErrorMessage(messages.estimate)

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -1,6 +1,6 @@
 const {workspace, commands, window} = require('vscode')
 const {createPTStatusBarItem} = require('../lib/pivotaly/createPTStatusBarItem')
-const {validate, validateStory} = require('../lib/validation/validate')
+const {validateStory} = require('../lib/validation/validate')
 const commandRepo = require('../lib/commands')
 const isRepo = require('../lib/validation/validators/isRepo')
 const {refreshState} = require('../lib/helpers/state')
@@ -67,13 +67,6 @@ const activate = async context => {
     commands.registerCommand(commandRepo.commands.internal.copyToClipboard, text => commandRepo.copy(text, context)),
     commands.registerCommand(commandRepo.commands.storyState.estimateStory, () => commandRepo.estimateStory(context, storyInfoProvider))
   )
-
-  validate('token', context).then(_didValidationSucceed => {
-    validate('projectID', context, true).then(_didProjectValidationSucceed => {
-      if (isARepo) validateStory(context, storyInfoProvider)
-      else validate('story', context, true).then(didSucceed => {}, didFail => {})
-    }, _didProjectValidationSucceed => {})
-  }, _didValidationSucceed => {})
 
   if(isARepo){
     unlinkGitEmit(context, rootPath)

--- a/out/pivotaly.js
+++ b/out/pivotaly.js
@@ -12,15 +12,7 @@ const CurrentAndBacklogDataProvider = require('../lib/views/currentandBacklog/cu
 const views = require('../lib/views/views')
 const unlinkGitEmit = require('../lib/fixes/unlinkGitEmit')
 const {listenForCheckOut} = require('../lib/helpers/git')
-
-
-const setUpNotPtProjectEnvironment = async context => {
-  const cpProvider = new ControlPanelDataProvider(context, null, null, false)
-  context.subscriptions.push(
-    window.registerTreeDataProvider(views.controlPanel, cpProvider),
-    commands.registerCommand(commandRepo.commands.internal.reinstateWorkspace, () => commandRepo.reinstateWorkspace(context))
-  )
-}
+const {setUpNotPtProjectEnvironment} = require('../lib/helpers/workspace')
 
 const activate = async context => {
   if(workspace.workspaceFolders === undefined) return
@@ -30,13 +22,13 @@ const activate = async context => {
   const isARepo = rootPath ? await isRepo(rootPath) : false
   context.workspaceState.update(common.globals.isARepo, isARepo)
 
-  if(context.workspaceState.get(common.globals.notPTProject)) return setUpNotPtProjectEnvironment(context);
+  if(context.workspaceState.get(common.globals.notPTProject)) return setUpNotPtProjectEnvironment(context, false)
 
   const statusBarItem = createPTStatusBarItem()
 
   const cycleTimeProvider = new CycleTimeDataProvider(context, 6, 'done_current')
   const storyInfoProvider = new StoryInfoDataProvider(context)
-  const cpProvider = new ControlPanelDataProvider(context, storyInfoProvider, cycleTimeProvider)
+  const cpProvider = new ControlPanelDataProvider(context, storyInfoProvider, cycleTimeProvider, true)
   const currentBacklogProvider = new CurrentAndBacklogDataProvider(context)
 
   context.subscriptions.push(


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
- Refactors registerToken and registerProjectID
- Refreshes backlog after registering token or projectID

#### How should this be manually tested?
- Edit token or project
- Backlog view should refresh to reflect changes

#### Any background context you want to provide?
 -- 
#### Screenshots (if appropriate)
--
#### Questions:
--