### PR TITLE
Add default token if token is not present

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -9,7 +9,7 @@ class Model {
     this._context = context
     this._pivotalTrackerClient = clients.createJsonClient(common.globals.pivotalBaseUrl)
     this._projectId = context.workspaceState.get(common.globals.projectID)
-    this._token = context.globalState.get(common.globals.APItoken)
+    this._token = context.globalState.get(common.globals.APItoken, ' ')
     this.retryLimit = 3
   }
 


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Adds default wrong token if token is not available

#### How should this be manually tested?
After deleting a token, on restart an input box should appear asking for a new token

#### Any background context you want to provide?
This issue potentially affects new users on v0.7 who might not have a token already saved in their device

#### Screenshots (if appropriate)

#### Questions:
