### PR TITLE
Bg prevent starting stories in protected branch 171707887

### DIFF
--- a/lib/commands/startStory.js
+++ b/lib/commands/startStory.js
@@ -7,6 +7,8 @@ const {getAllBranches, checkoutToBranch, checkoutFromBranch} = require('../helpe
 const {validateStory} = require('../validation/validate')
 const {isBranchDefault} = require('../validation/validators/isBranchDefault')
 
+const isDefaultBranch = async (context, branch) => !(await isBranchDefault(context, branch))
+
 /**
  * Starts the current story or provided story in the backlog tree item
  * @param {object} context Extension host context object
@@ -72,8 +74,10 @@ const checkOutExistingBranch = async (context, storyInfoDataProvider, branches) 
     canPickMany: false,
     placeHolder: "Choose branch to use"
   })
-  const isDefaultBranch = !(await isBranchDefault(context, newBranch))
-  if(!newBranch || isDefaultBranch)
+  
+  const isPickedBranchDefault = await isDefaultBranch(context, newBranch)
+
+  if(!newBranch || isPickedBranchDefault)
     throw new Error('Could not create new branch. You might have picked a protected branch')
 
   await checkoutToBranch(context, newBranch, validateStory, context, storyInfoDataProvider)

--- a/lib/commands/startStory.js
+++ b/lib/commands/startStory.js
@@ -3,7 +3,7 @@ const PtStory = require('../../model/stories')
 const {getState, setState} = require('../helpers/state')
 const rebounds = require('../validation/rebounds')
 const {common} = require('./common')
-const {getAllBranches, checkoutToBranch, checkoutFromBranch} = require('../helpers/git')
+const {getAllBranches, checkoutToBranch, checkoutFromBranch, getActiveBranch} = require('../helpers/git')
 const {validateStory} = require('../validation/validate')
 const {isBranchDefault} = require('../validation/validators/isBranchDefault')
 
@@ -46,7 +46,7 @@ const startStoryFromBacklogViewlet = async (context, storyInfoDataProvider, back
   if(isARepo) {
     const branches = await getAllBranches()
     const checkoutOptions = {
-      'Start story in current branch': async () => Promise.resolve(''),
+      'Start story in current branch': async () => startStoryInCurrentBranch(context),
       'Start story in existing branch': async () => checkOutExistingBranch(context, storyInfoDataProvider, branches),
       'Start story in new branch': async () => checkOutNewBranch(context, storyInfoDataProvider, backlogTreeItem, branches)
     }
@@ -60,6 +60,17 @@ const startStoryFromBacklogViewlet = async (context, storyInfoDataProvider, back
     }
   }
   afterCheckout(context, newBranch, storyInfoDataProvider, backlogTreeItem)
+}
+
+const startStoryInCurrentBranch = async (context) => {
+  const currentBranch = await getActiveBranch()
+  const isCurrentBranchDefault = await isDefaultBranch(context, currentBranch)
+
+  if (isCurrentBranchDefault) {
+    throw new Error('You are in a protected branch. Switch to a feature branch to start story')
+  }
+
+  return ''
 }
 
 /**

--- a/lib/commands/startStory.spec.js
+++ b/lib/commands/startStory.spec.js
@@ -15,7 +15,7 @@ const startStory = require('./startStory')
 const Context = require('../../test/factories/vscode/context')
 const StoryInfoDataProvider = require('../views/storyInfo/storyInfoDataProvider')
 const {setState} = require('../helpers/state')
-const {checkoutToBranch, checkoutFromBranch, getAllBranches} = require('../helpers/git')
+const {checkoutToBranch, checkoutFromBranch, getAllBranches, getActiveBranch} = require('../helpers/git')
 const {isBranchDefault} = require('../validation/validators/isBranchDefault')
 
 const chance = new Chance()
@@ -116,6 +116,9 @@ describe('#startStory', () => {
   })
 
   describe('Start story in current branch', () => {
+    getActiveBranch.mockResolvedValue(chance.string())
+    context.workspaceState.get = jest.fn(() => true)
+
     afterEach(() => {
       jest.clearAllMocks()
     })
@@ -131,11 +134,19 @@ describe('#startStory', () => {
     }
 
     test('sets new branch to a falsy value', async () => {
-      context.workspaceState.get = jest.fn(() => true)
       vscode.window.showQuickPick = jest.fn().mockResolvedValue('Start story in current branch')
+      isBranchDefault.mockResolvedValue(true)
       await startStory(context, StoryInfoProvider, backlogTreeItem)
       expect(setState).toBeCalledTimes(1)
       expect(setState.mock.calls[0][1]).toBeFalsy()
+    })
+
+    test('does not start story if branch is default', async () => {
+      vscode.window.showQuickPick = jest.fn().mockResolvedValue('Start story in current branch')
+      isBranchDefault.mockResolvedValue(false)
+      await startStory(context, StoryInfoProvider, backlogTreeItem)
+      expect(rebounds).toBeCalledTimes(1)
+      expect(rebounds.mock.calls[0][0]).toBe('checkOutFailed')
     })
   })
 


### PR DESCRIPTION
#### What does this PR do? / Fixes issue
Prevents starting stories on default branches from the backlog view

#### How should this be manually tested?
- Switch to a default branch
- Attempt to start a story from the backlog view on the current branch
- The action should fail

#### Any background context you want to provide?
A bug allowed stories to start on default branches when started from the backlog view

#### Screenshots (if appropriate)
N/A
#### Questions:
N/A